### PR TITLE
Support macOS and clang

### DIFF
--- a/grammar.rustpeg
+++ b/grammar.rustpeg
@@ -604,6 +604,9 @@ type_qualifier0 -> TypeQualifier =
     K<"const"    / gnu<"__const">> { TypeQualifier::Const } /
     K<"restrict" / gnu<"__restrict" "__"?>> { TypeQualifier::Restrict } /
     K<"volatile" / gnu<"__volatile" "__"?>> { TypeQualifier::Volatile } /
+    clang<"_Nonnull"> { TypeQualifier::Nonnull } /
+    clang<"_Null_unspecified"> { TypeQualifier::NullUnspecified } /
+    clang<"_Nullable"> { TypeQualifier::Nullable } /
     K<"_Atomic"> { TypeQualifier::Atomic }
 
 ////
@@ -1237,3 +1240,11 @@ ts18661_float_suffix -> TS18661FloatType =
     [dD] width:ts18661_decimal_width extended:"x"? {
         ts18661_float(false, width, extended.is_some())
     }
+
+////
+// Clang extensions
+////
+
+clang<E> = &clang_guard e:E { e }
+
+clang_guard = {? if env.extensions_clang { Ok(()) } else { Err("clang extensions disabled") } }

--- a/grammar.rustpeg
+++ b/grammar.rustpeg
@@ -604,9 +604,9 @@ type_qualifier0 -> TypeQualifier =
     K<"const"    / gnu<"__const">> { TypeQualifier::Const } /
     K<"restrict" / gnu<"__restrict" "__"?>> { TypeQualifier::Restrict } /
     K<"volatile" / gnu<"__volatile" "__"?>> { TypeQualifier::Volatile } /
-    clang<"_Nonnull"> { TypeQualifier::Nonnull } /
-    clang<"_Null_unspecified"> { TypeQualifier::NullUnspecified } /
-    clang<"_Nullable"> { TypeQualifier::Nullable } /
+    clang<K<"_Nonnull">> { TypeQualifier::Nonnull } /
+    clang<K<"_Null_unspecified">> { TypeQualifier::NullUnspecified } /
+    clang<K<"_Nullable">> { TypeQualifier::Nullable } /
     K<"_Atomic"> { TypeQualifier::Atomic }
 
 ////

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -745,10 +745,16 @@ pub enum TypeQualifier {
     /// `__volatile`, `__volatile__` (GNU extension)
     Volatile,
     /// '_Nonnull' (Clang extension)
+    ///
+    /// [Clang extension](https://clang.llvm.org/docs/AttributeReference.html)
     Nonnull,
     /// '_Null_unspecified' (Clang extension)
+    ///
+    /// [Clang extension](https://clang.llvm.org/docs/AttributeReference.html)
     NullUnspecified,
     /// '_Nullable' (Clang extension)
+    ///
+    /// [Clang extension](https://clang.llvm.org/docs/AttributeReference.html)
     Nullable,
     /// `_Atomic`
     Atomic,

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -744,6 +744,12 @@ pub enum TypeQualifier {
     ///
     /// `__volatile`, `__volatile__` (GNU extension)
     Volatile,
+    /// '_Nonnull' (Clang extension)
+    Nonnull,
+    /// '_Null_unspecified' (Clang extension)
+    NullUnspecified,
+    /// '_Nullable' (Clang extension)
+    Nullable,
     /// `_Atomic`
     Atomic,
 }

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -27,6 +27,8 @@ pub enum Flavor {
     StdC11,
     /// Standard C11 with GNU extensions
     GnuC11,
+    /// Standard C11 with Clang extensions
+    ClangC11,
 }
 
 impl Default for Flavor {
@@ -129,8 +131,9 @@ pub fn parse<P: AsRef<Path>>(config: &Config, source: P) -> Result<Parse, Error>
 
 pub fn parse_preprocessed(config: &Config, source: String) -> Result<Parse, SyntaxError> {
     let mut env = match config.flavor {
-        Flavor::StdC11 => Env::with_gnu(false),
-        Flavor::GnuC11 => Env::with_gnu(true),
+        Flavor::StdC11 => Env::with_core(),
+        Flavor::GnuC11 => Env::with_gnu(),
+        Flavor::ClangC11 => Env::with_clang(),
     };
 
     match translation_unit(&source, &mut env) {

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -149,7 +149,16 @@ pub fn parse_preprocessed(config: &Config, source: String) -> Result<Parse, Synt
 }
 
 fn preprocess(config: &Config, source: &Path) -> io::Result<String> {
-    let mut cmd = Command::new("cpp");
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    compile_error!("I don't know what preprocessor to use for your OS");
+
+    let mut cmd;
+    if cfg!(target_os = "linux") {
+        cmd = Command::new("cpp");
+    } else {  // macos
+        cmd = Command::new("clang");
+        cmd.arg("-E".to_string());
+    }
 
     for item in &config.options {
         cmd.arg(item);

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -152,15 +152,13 @@ pub fn parse_preprocessed(config: &Config, source: String) -> Result<Parse, Synt
 }
 
 fn preprocess(config: &Config, source: &Path) -> io::Result<String> {
-    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
-    compile_error!("I don't know what preprocessor to use for your OS");
-
     let mut cmd;
-    if cfg!(target_os = "linux") {
-        cmd = Command::new("cpp");
-    } else {  // macos
+    if cfg!(target_os = "macos") {
+        // cpp on macOS will not work for C11
         cmd = Command::new("clang");
         cmd.arg("-E".to_string());
+    } else {
+        cmd = Command::new("cpp");
     }
 
     for item in &config.options {

--- a/src/env.rs
+++ b/src/env.rs
@@ -7,28 +7,51 @@ use strings;
 pub struct Env {
     pub typenames: Vec<HashSet<String>>,
     pub extensions_gnu: bool,
+    pub extensions_clang: bool,
     pub reserved: HashSet<&'static str>,
 }
 
 impl Env {
     #[cfg(test)]
     pub fn new() -> Env {
-        Env::with_gnu(true)
+        Env::with_gnu()
     }
 
-    pub fn with_gnu(enable: bool) -> Env {
-        let mut typenames = HashSet::default();
-
+    pub fn with_core() -> Env {
         let mut reserved = HashSet::default();
         reserved.extend(strings::RESERVED_C11.iter());
-
-        if enable {
-            typenames.insert("__builtin_va_list".to_owned());
-            reserved.extend(strings::RESERVED_GNU.iter());
-        }
-
         Env {
-            extensions_gnu: enable,
+            extensions_gnu: false,
+            extensions_clang: false,
+            typenames: Vec::new(),
+            reserved: reserved,
+        }
+    }
+
+    pub fn with_gnu() -> Env {
+        let mut typenames = HashSet::default();
+        let mut reserved = HashSet::default();
+        typenames.insert("__builtin_va_list".to_owned());
+        reserved.extend(strings::RESERVED_C11.iter());
+        reserved.extend(strings::RESERVED_GNU.iter());
+        Env {
+            extensions_gnu: true,
+            extensions_clang: false,
+            typenames: vec![typenames],
+            reserved: reserved,
+        }
+    }
+
+    pub fn with_clang() -> Env {
+        let mut typenames = HashSet::default();
+        let mut reserved = HashSet::default();
+        typenames.insert("__builtin_va_list".to_owned());
+        reserved.extend(strings::RESERVED_C11.iter());
+        reserved.extend(strings::RESERVED_GNU.iter());
+        reserved.extend(strings::RESERVED_CLANG.iter());
+        Env {
+            extensions_gnu: true,
+            extensions_clang: true,
             typenames: vec![typenames],
             reserved: reserved,
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -7656,7 +7656,40 @@ fn __parse_type_qualifier0<'input>(__input: &'input str, __state: &mut ParseStat
                                         };
                                         match __seq_res {
                                             Matched(__pos, _) => {
-                                                let __seq_res = slice_eq(__input, __state, __pos, "_Nonnull");
+                                                let __seq_res = {
+                                                    __state.suppress_fail += 1;
+                                                    let res = {
+                                                        let __seq_res = slice_eq(__input, __state, __pos, "_Nonnull");
+                                                        match __seq_res {
+                                                            Matched(__pos, e) => {
+                                                                let __seq_res = {
+                                                                    __state.suppress_fail += 1;
+                                                                    let __assert_res = if __input.len() > __pos {
+                                                                        let (__ch, __next) = char_range_at(__input, __pos);
+                                                                        match __ch {
+                                                                            '_' | 'a'...'z' | 'A'...'Z' | '0'...'9' => Matched(__next, ()),
+                                                                            _ => __state.mark_failure(__pos, "[_a-zA-Z0-9]"),
+                                                                        }
+                                                                    } else {
+                                                                        __state.mark_failure(__pos, "[_a-zA-Z0-9]")
+                                                                    };
+                                                                    __state.suppress_fail -= 1;
+                                                                    match __assert_res {
+                                                                        Failed => Matched(__pos, ()),
+                                                                        Matched(..) => Failed,
+                                                                    }
+                                                                };
+                                                                match __seq_res {
+                                                                    Matched(__pos, _) => Matched(__pos, { e }),
+                                                                    Failed => Failed,
+                                                                }
+                                                            }
+                                                            Failed => Failed,
+                                                        }
+                                                    };
+                                                    __state.suppress_fail -= 1;
+                                                    res
+                                                };
                                                 match __seq_res {
                                                     Matched(__pos, e) => Matched(__pos, { e }),
                                                     Failed => Failed,
@@ -7686,7 +7719,40 @@ fn __parse_type_qualifier0<'input>(__input: &'input str, __state: &mut ParseStat
                                                 };
                                                 match __seq_res {
                                                     Matched(__pos, _) => {
-                                                        let __seq_res = slice_eq(__input, __state, __pos, "_Null_unspecified");
+                                                        let __seq_res = {
+                                                            __state.suppress_fail += 1;
+                                                            let res = {
+                                                                let __seq_res = slice_eq(__input, __state, __pos, "_Null_unspecified");
+                                                                match __seq_res {
+                                                                    Matched(__pos, e) => {
+                                                                        let __seq_res = {
+                                                                            __state.suppress_fail += 1;
+                                                                            let __assert_res = if __input.len() > __pos {
+                                                                                let (__ch, __next) = char_range_at(__input, __pos);
+                                                                                match __ch {
+                                                                                    '_' | 'a'...'z' | 'A'...'Z' | '0'...'9' => Matched(__next, ()),
+                                                                                    _ => __state.mark_failure(__pos, "[_a-zA-Z0-9]"),
+                                                                                }
+                                                                            } else {
+                                                                                __state.mark_failure(__pos, "[_a-zA-Z0-9]")
+                                                                            };
+                                                                            __state.suppress_fail -= 1;
+                                                                            match __assert_res {
+                                                                                Failed => Matched(__pos, ()),
+                                                                                Matched(..) => Failed,
+                                                                            }
+                                                                        };
+                                                                        match __seq_res {
+                                                                            Matched(__pos, _) => Matched(__pos, { e }),
+                                                                            Failed => Failed,
+                                                                        }
+                                                                    }
+                                                                    Failed => Failed,
+                                                                }
+                                                            };
+                                                            __state.suppress_fail -= 1;
+                                                            res
+                                                        };
                                                         match __seq_res {
                                                             Matched(__pos, e) => Matched(__pos, { e }),
                                                             Failed => Failed,
@@ -7716,7 +7782,40 @@ fn __parse_type_qualifier0<'input>(__input: &'input str, __state: &mut ParseStat
                                                         };
                                                         match __seq_res {
                                                             Matched(__pos, _) => {
-                                                                let __seq_res = slice_eq(__input, __state, __pos, "_Nullable");
+                                                                let __seq_res = {
+                                                                    __state.suppress_fail += 1;
+                                                                    let res = {
+                                                                        let __seq_res = slice_eq(__input, __state, __pos, "_Nullable");
+                                                                        match __seq_res {
+                                                                            Matched(__pos, e) => {
+                                                                                let __seq_res = {
+                                                                                    __state.suppress_fail += 1;
+                                                                                    let __assert_res = if __input.len() > __pos {
+                                                                                        let (__ch, __next) = char_range_at(__input, __pos);
+                                                                                        match __ch {
+                                                                                            '_' | 'a'...'z' | 'A'...'Z' | '0'...'9' => Matched(__next, ()),
+                                                                                            _ => __state.mark_failure(__pos, "[_a-zA-Z0-9]"),
+                                                                                        }
+                                                                                    } else {
+                                                                                        __state.mark_failure(__pos, "[_a-zA-Z0-9]")
+                                                                                    };
+                                                                                    __state.suppress_fail -= 1;
+                                                                                    match __assert_res {
+                                                                                        Failed => Matched(__pos, ()),
+                                                                                        Matched(..) => Failed,
+                                                                                    }
+                                                                                };
+                                                                                match __seq_res {
+                                                                                    Matched(__pos, _) => Matched(__pos, { e }),
+                                                                                    Failed => Failed,
+                                                                                }
+                                                                            }
+                                                                            Failed => Failed,
+                                                                        }
+                                                                    };
+                                                                    __state.suppress_fail -= 1;
+                                                                    res
+                                                                };
                                                                 match __seq_res {
                                                                     Matched(__pos, e) => Matched(__pos, { e }),
                                                                     Failed => Failed,

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -92,3 +92,46 @@ pub const RESERVED_GNU: &'static [&'static str] = &[
     "__volatile",
     "__volatile__",
 ];
+
+// Ref: https://clang.llvm.org/docs/AttributeReference.html
+pub const RESERVED_CLANG: &'static [&'static str] = &[
+    // Only enabled with -fms-extensions and only affect *-*-win32 targets
+    "__single_inheritance",
+    "__multiple_inheritance",
+    "__virtual_inheritance",
+    "__unspecified_inheritance",
+    // OpenCL v2.0
+    "__read_only",
+    "read_only",
+    "__write_only",
+    "write_only",
+    "__read_write",
+    "read_write",
+    // Calling conventions
+    "_fastcall",
+    "_fastcall",
+    "__regcall",
+    "__stdcall",
+    "_stdcall",
+    "__thiscall",
+    "_thiscall",
+    "__vectorcall",
+    "_vectorcall",
+    // OpenCL Address Spaces
+    "__constant",
+    "constant",
+    "__generic",
+    "generic",
+    "__global",
+    "global",
+    "__local",
+    "local",
+    "__private",
+    "private",
+    // Nullability attributes
+    "_Nonnull",
+    "_Null_unspecified",
+    "_Nullable",
+    "nonnull",
+    "returns_nonnull",
+];


### PR DESCRIPTION
I wanted to try your library on a Mac, but was stymied by two issues:

1. `cpp` is broken on macOS in that it's both stuck in K&R mode and has a bug surrounding its handling of indented preprocessor directives. Ref: [Stack Overflow](https://stackoverflow.com/questions/42031921/unterminated-unconditional-directive-error-when-preprocessing-c-code). To this end:
    1. I submit a patch to use `clang -E` when `target_os = macos`.
    2. Incidentally, if `target_os` is not `linux` or `macos`, I throw a compile error. Thus Windows is _explicitly_ not yet supported (this project's only open issue).
    3. I only tested on macOS 10.14.2, as I don't have a Linux box in a working state at the moment, so I hope you'll help me fill in the testing there.
2. Once you pre-process with Clang on macOS, trivial programs parse fine, but as soon as you import any standard headers, you get a `SyntaxError`. In the case of `stdio.h`, it's because it uses a new type qualifier `_Nullable`, which is not defined elsewhere. It turns out that it's a Clang extension. To address this, I added some Clang support:
    1. I added the nullability qualifiers to the grammar.
    2. I listed all the [Clang-specific keywords](https://clang.llvm.org/docs/AttributeReference.html#nullability-attributes) I could find in `strings.rs`.
    3. Clang seems to support an almost super-set of the gcc extensions, so I added a new `Flavor::Clang11` and reworked the `Env` initialization to make "core" C11 a subset of gnu11 and gnu11 a subset of Clang11.
    4. I added one test for the grammar additions and the new `Env` option.
    5. What's missing: I didn't add the other keywords words to the grammar. These include things like controlling OpenCL address spaces and some Windows-specific MS extensions. I also didn't update the readme. I figure you would want to choose what to say, if anything.

I hope you'll consider taking these patches. I'm very open to feedback, particularly as I'm somewhat new to Rust.