### PR TITLE
Fixing most type specifier ambiguous cases.

### DIFF
--- a/grammar.rustpeg
+++ b/grammar.rustpeg
@@ -21,6 +21,19 @@ list1<ex> = e:ex ++ _ { e }
 cs0<ex> = e:ex ** (_ "," _) { e }
 cs1<ex> = e:ex ++ (_ "," _) { e }
 
+// A list containing 0+ before's, 1 single, and 0+ after's.
+list_010<before, single, after> =
+    before:list0<before> _ single:single _ after:list0<after> {
+        let mut before = before;
+        before.push(single);
+        before.extend(after);
+        before
+    }
+// A list containing *exactly* one element of a, and any of b.
+list_eq1_n<a, b> = list_010<b, a, b>
+// A list containing *at least* one element of a, and any of b.
+list_ge1_n<a, b> = list_010<b, a, a / b>
+
 ////
 // Whitespace
 ////
@@ -440,27 +453,37 @@ constant_expression0 -> Expression = conditional_expression0
 ////
 
 pub declaration -> Node<Declaration> = d:node<declaration0> {
-        env.handle_declaration(&d.node);
+        env.handle_declaration(
+                    &d.node.specifiers,
+                    d.node.declarators.iter().map(|d| &d.node.declarator),
+        );
         d
     }
 
 declaration0 -> Declaration =
-    gnu<K<"__extension__">>? _ s:list1<declaration_specifier> _ d:cs0<node<init_declarator>> _ ";" {
+    gnu<K<"__extension__">>? _ s:declaration_specifiers _ d:cs0<node<init_declarator>> _ ";" {
         Declaration {
             specifiers: s,
             declarators: d,
         }
     }
 
-declaration_specifier -> Node<DeclarationSpecifier> = node<declaration_specifier0>
+declaration_specifiers -> Vec<Node<DeclarationSpecifier>> =
+    list_eq1_n<node<declaration_specifier_unique_type0>, node<declaration_specifier0>> /
+    list_ge1_n<node<declaration_specifier_nonunique_type0>, node<declaration_specifier0>>
 
 declaration_specifier0 -> DeclarationSpecifier =
     s:storage_class_specifier { DeclarationSpecifier::StorageClass(s) } /
-    s:type_specifier { DeclarationSpecifier::TypeSpecifier(s) } /
     s:type_qualifier { DeclarationSpecifier::TypeQualifier(s) } /
     s:function_specifier { DeclarationSpecifier::Function(s) } /
     s:alignment_specifier { DeclarationSpecifier::Alignment(s) } /
     s:gnu<attribute_specifier> { DeclarationSpecifier::Extension(s) }
+
+declaration_specifier_unique_type0 -> DeclarationSpecifier =
+    s:node<type_specifier_unique> { DeclarationSpecifier::TypeSpecifier(s) }
+
+declaration_specifier_nonunique_type0 -> DeclarationSpecifier =
+    s:node<type_specifier_nonunique> { DeclarationSpecifier::TypeSpecifier(s) }
 
 init_declarator -> InitDeclarator =
     d:declarator _ e:gnu<init_declarator_gnu>? _ i:node<init_declarator_init>?
@@ -495,10 +518,18 @@ storage_class_specifier0 -> StorageClassSpecifier =
 // 6.7.2 Type specifiers
 ////
 
-type_specifier -> Node<TypeSpecifier> = node<type_specifier0>
-
-type_specifier0 -> TypeSpecifier =
+// ISO 2011, 6.7.2, §2. Void, _Bool, _Atomic, typedef names, struct/unions, and enum
+// specifiers can only appear once in declaration specifiers or specifier-qualifiers.
+// This resolves the ambiguity with typedef names.
+type_specifier_unique -> TypeSpecifier =
     K<"void"> { TypeSpecifier::Void } /
+    K<"_Bool"> { TypeSpecifier::Bool } /
+    K<"_Atomic"> _ "(" _ t:type_name _ ")" { TypeSpecifier::Atomic(t) } /
+    s:node<struct_or_union_specifier> { TypeSpecifier::Struct(s) } /
+    e:node<enum_specifier> { TypeSpecifier::Enum(e) } /
+    t:typedef_name { TypeSpecifier::TypedefName(t) }
+
+type_specifier_nonunique -> TypeSpecifier =
     K<"char"> { TypeSpecifier::Char } /
     K<"short"> { TypeSpecifier::Short } /
     K<"int"> { TypeSpecifier::Int } /
@@ -507,13 +538,8 @@ type_specifier0 -> TypeSpecifier =
     K<"double"> { TypeSpecifier::Double } /
     K<"signed" / gnu<"__signed" "__"?>> { TypeSpecifier::Signed } /
     K<"unsigned"> { TypeSpecifier::Unsigned } /
-    K<"_Bool"> { TypeSpecifier::Bool } /
     K<"_Complex" / gnu<"__complex" "__"?>> { TypeSpecifier::Complex } /
-    K<"_Atomic"> _ "(" _ t:type_name _ ")" { TypeSpecifier::Atomic(t) } /
     t:K<ts18661_float_type_specifier> { TypeSpecifier::TS18661Float(t) } /
-    t:typedef_name { TypeSpecifier::TypedefName(t) } /
-    s:node<struct_or_union_specifier> { TypeSpecifier::Struct(s) } /
-    e:node<enum_specifier> { TypeSpecifier::Enum(e) } /
     gnu<typeof_specifier>
 
 struct_or_union_specifier -> StructType =
@@ -547,17 +573,24 @@ struct_declaration -> StructDeclaration =
     gnu<K<"__extension__">> _ d:struct_declaration { d }
 
 struct_field -> StructField =
-    s:list1<specifier_qualifier> _ d:cs0<node<struct_declarator>> _ ";" {
+    s:specifier_qualifiers _ d:cs0<node<struct_declarator>> _ ";" {
         StructField {
             specifiers: s,
             declarators: d,
         }
     }
 
-specifier_qualifier -> Node<SpecifierQualifier> = node<specifier_qualifier0>
+specifier_qualifiers -> Vec<Node<SpecifierQualifier>> =
+    list_eq1_n<node<specifier_qualifier_unique_type0>, node<specifier_qualifier_qualifier0>> /
+    list_ge1_n<node<specifier_qualifier_nonunique_type0>, node<specifier_qualifier_qualifier0>>
 
-specifier_qualifier0 -> SpecifierQualifier =
-    s:type_specifier { SpecifierQualifier::TypeSpecifier(s) } /
+specifier_qualifier_unique_type0 -> SpecifierQualifier =
+    s:node<type_specifier_unique> { SpecifierQualifier::TypeSpecifier(s) }
+
+specifier_qualifier_nonunique_type0 -> SpecifierQualifier =
+    s:node<type_specifier_nonunique> { SpecifierQualifier::TypeSpecifier(s) }
+
+specifier_qualifier_qualifier0 -> SpecifierQualifier =
     q:type_qualifier { SpecifierQualifier::TypeQualifier(q) }
 
 struct_declarator -> StructDeclarator =
@@ -612,7 +645,8 @@ type_qualifier0 -> TypeQualifier =
     clang<K<"_Nonnull">> { TypeQualifier::Nonnull } /
     clang<K<"_Null_unspecified">> { TypeQualifier::NullUnspecified } /
     clang<K<"_Nullable">> { TypeQualifier::Nullable } /
-    K<"_Atomic"> { TypeQualifier::Atomic }
+    // 6.7.2.4: _Atomics followed by a "(" are interpreted as type specifiers.
+    K<"_Atomic"> _ !"(" { TypeQualifier::Atomic }
 
 ////
 // 6.7.4 Function specifiers
@@ -659,7 +693,7 @@ direct_declarator -> DeclaratorKind =
 
 derived_declarator -> DerivedDeclarator =
     "[" _ a:node<array_declarator> { DerivedDeclarator::Array(a) } /
-    "(" _ f:node<function_declarator> _ ")" { DerivedDeclarator::Function(f) } /
+    "(" _ f:scoped<node<function_declarator>> _ ")" { DerivedDeclarator::Function(f) } /
     "(" _ p:cs0<identifier> _ ")" { DerivedDeclarator::KRFunction(p) }
 
 array_declarator -> ArrayDeclarator =
@@ -717,7 +751,8 @@ ellipsis -> Ellipsis =
 parameter_declaration -> Node<ParameterDeclaration> = node<parameter_declaration0>
 
 parameter_declaration0 -> ParameterDeclaration =
-    s:list1<declaration_specifier> _ d:parameter_declarator _ a:gnu<attribute_specifier_list>? {
+    s:declaration_specifiers _ d:parameter_declarator _ a:gnu<attribute_specifier_list>? {
+        env.handle_declaration(&s, d.iter());
         ParameterDeclaration {
             specifiers: s,
             declarator: d,
@@ -737,7 +772,7 @@ parameter_declarator -> Option<Node<Declarator>> =
 type_name -> Node<TypeName> = node<type_name0>
 
 type_name0 -> TypeName =
-    s:list1<specifier_qualifier> _ d:abstract_declarator? {
+    s:specifier_qualifiers _ d:abstract_declarator? {
         TypeName {
             specifiers: s,
             declarator: d,
@@ -905,10 +940,10 @@ pub statement -> Box<Node<Statement>> = box<node<statement0>>
 
 statement0 -> Statement =
     s:node<labeled_statement> { Statement::Labeled(s) } /
-    compound_statement /
+    scoped<compound_statement> /
     expression_statement /
     selection_statement /
-    iteration_statement /
+    scoped<iteration_statement> /
     jump_statement /
     gnu<asm_statement>
 
@@ -1042,7 +1077,7 @@ external_declaration -> ExternalDeclaration =
 
 function_definition -> FunctionDefinition =
     gnu<K<"__extension__">>?
-    _ a:list1<declaration_specifier> _ b:declarator _ c:list0<declaration>
+    _ a:declaration_specifiers _ b:declarator _ c:list0<declaration>
     _ d:node<compound_statement> {
         FunctionDefinition {
             specifiers: a,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -30,16 +30,16 @@ pub struct ParseError {
 pub type ParseResult<T> = Result<T, ParseError>;
 impl ::std::fmt::Display for ParseError {
     fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::result::Result<(), ::std::fmt::Error> {
-        try!(write!(fmt, "error at {}:{}: expected ", self.line, self.column));
+        write!(fmt, "error at {}:{}: expected ", self.line, self.column)?;
         if self.expected.len() == 0 {
-            try!(write!(fmt, "EOF"));
+            write!(fmt, "EOF")?;
         } else if self.expected.len() == 1 {
-            try!(write!(fmt, "`{}`", escape_default(self.expected.iter().next().unwrap())));
+            write!(fmt, "`{}`", escape_default(self.expected.iter().next().unwrap()))?;
         } else {
             let mut iter = self.expected.iter();
-            try!(write!(fmt, "one of `{}`", escape_default(iter.next().unwrap())));
+            write!(fmt, "one of `{}`", escape_default(iter.next().unwrap()))?;
             for elem in iter {
-                try!(write!(fmt, ", `{}`", escape_default(elem)));
+                write!(fmt, ", `{}`", escape_default(elem))?;
             }
         }
         Ok(())
@@ -4916,7 +4916,7 @@ fn __parse_declaration<'input>(__input: &'input str, __state: &mut ParseState<'i
         };
         match __seq_res {
             Matched(__pos, d) => Matched(__pos, {
-                env.handle_declaration(&d.node);
+                env.handle_declaration(&d.node.specifiers, d.node.declarators.iter().map(|d| &d.node.declarator));
                 d
             }),
             Failed => Failed,
@@ -4989,43 +4989,7 @@ fn __parse_declaration0<'input>(__input: &'input str, __state: &mut ParseState<'
                 let __seq_res = __parse__(__input, __state, __pos, env);
                 match __seq_res {
                     Matched(__pos, _) => {
-                        let __seq_res = {
-                            let __seq_res = {
-                                let mut __repeat_pos = __pos;
-                                let mut __repeat_value = vec![];
-                                loop {
-                                    let __pos = __repeat_pos;
-                                    let __pos = if __repeat_value.len() > 0 {
-                                        let __sep_res = __parse__(__input, __state, __pos, env);
-                                        match __sep_res {
-                                            Matched(__newpos, _) => __newpos,
-                                            Failed => break,
-                                        }
-                                    } else {
-                                        __pos
-                                    };
-                                    let __step_res = __parse_declaration_specifier(__input, __state, __pos, env);
-                                    match __step_res {
-                                        Matched(__newpos, __value) => {
-                                            __repeat_pos = __newpos;
-                                            __repeat_value.push(__value);
-                                        }
-                                        Failed => {
-                                            break;
-                                        }
-                                    }
-                                }
-                                if __repeat_value.len() >= 1 {
-                                    Matched(__repeat_pos, __repeat_value)
-                                } else {
-                                    Failed
-                                }
-                            };
-                            match __seq_res {
-                                Matched(__pos, e) => Matched(__pos, { e }),
-                                Failed => Failed,
-                            }
-                        };
+                        let __seq_res = __parse_declaration_specifiers(__input, __state, __pos, env);
                         match __seq_res {
                             Matched(__pos, s) => {
                                 let __seq_res = __parse__(__input, __state, __pos, env);
@@ -5125,25 +5089,343 @@ fn __parse_declaration0<'input>(__input: &'input str, __state: &mut ParseState<'
     }
 }
 
-fn __parse_declaration_specifier<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Node<DeclarationSpecifier>> {
+fn __parse_declaration_specifiers<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Vec<Node<DeclarationSpecifier>>> {
     #![allow(non_snake_case, unused)]
     {
-        let __seq_res = Matched(__pos, __pos);
-        match __seq_res {
-            Matched(__pos, l) => {
-                let __seq_res = __parse_declaration_specifier0(__input, __state, __pos, env);
+        let __choice_res = {
+            let __seq_res = {
+                let __seq_res = {
+                    let mut __repeat_pos = __pos;
+                    let mut __repeat_value = vec![];
+                    loop {
+                        let __pos = __repeat_pos;
+                        let __pos = if __repeat_value.len() > 0 {
+                            let __sep_res = __parse__(__input, __state, __pos, env);
+                            match __sep_res {
+                                Matched(__newpos, _) => __newpos,
+                                Failed => break,
+                            }
+                        } else {
+                            __pos
+                        };
+                        let __step_res = {
+                            let __seq_res = Matched(__pos, __pos);
+                            match __seq_res {
+                                Matched(__pos, l) => {
+                                    let __seq_res = __parse_declaration_specifier0(__input, __state, __pos, env);
+                                    match __seq_res {
+                                        Matched(__pos, e) => {
+                                            let __seq_res = Matched(__pos, __pos);
+                                            match __seq_res {
+                                                Matched(__pos, r) => Matched(__pos, { Node::new(e, Span::span(l, r)) }),
+                                                Failed => Failed,
+                                            }
+                                        }
+                                        Failed => Failed,
+                                    }
+                                }
+                                Failed => Failed,
+                            }
+                        };
+                        match __step_res {
+                            Matched(__newpos, __value) => {
+                                __repeat_pos = __newpos;
+                                __repeat_value.push(__value);
+                            }
+                            Failed => {
+                                break;
+                            }
+                        }
+                    }
+                    Matched(__repeat_pos, __repeat_value)
+                };
                 match __seq_res {
-                    Matched(__pos, e) => {
-                        let __seq_res = Matched(__pos, __pos);
+                    Matched(__pos, e) => Matched(__pos, { e }),
+                    Failed => Failed,
+                }
+            };
+            match __seq_res {
+                Matched(__pos, before) => {
+                    let __seq_res = __parse__(__input, __state, __pos, env);
+                    match __seq_res {
+                        Matched(__pos, _) => {
+                            let __seq_res = {
+                                let __seq_res = Matched(__pos, __pos);
+                                match __seq_res {
+                                    Matched(__pos, l) => {
+                                        let __seq_res = __parse_declaration_specifier_unique_type0(__input, __state, __pos, env);
+                                        match __seq_res {
+                                            Matched(__pos, e) => {
+                                                let __seq_res = Matched(__pos, __pos);
+                                                match __seq_res {
+                                                    Matched(__pos, r) => Matched(__pos, { Node::new(e, Span::span(l, r)) }),
+                                                    Failed => Failed,
+                                                }
+                                            }
+                                            Failed => Failed,
+                                        }
+                                    }
+                                    Failed => Failed,
+                                }
+                            };
+                            match __seq_res {
+                                Matched(__pos, single) => {
+                                    let __seq_res = __parse__(__input, __state, __pos, env);
+                                    match __seq_res {
+                                        Matched(__pos, _) => {
+                                            let __seq_res = {
+                                                let __seq_res = {
+                                                    let mut __repeat_pos = __pos;
+                                                    let mut __repeat_value = vec![];
+                                                    loop {
+                                                        let __pos = __repeat_pos;
+                                                        let __pos = if __repeat_value.len() > 0 {
+                                                            let __sep_res = __parse__(__input, __state, __pos, env);
+                                                            match __sep_res {
+                                                                Matched(__newpos, _) => __newpos,
+                                                                Failed => break,
+                                                            }
+                                                        } else {
+                                                            __pos
+                                                        };
+                                                        let __step_res = {
+                                                            let __seq_res = Matched(__pos, __pos);
+                                                            match __seq_res {
+                                                                Matched(__pos, l) => {
+                                                                    let __seq_res = __parse_declaration_specifier0(__input, __state, __pos, env);
+                                                                    match __seq_res {
+                                                                        Matched(__pos, e) => {
+                                                                            let __seq_res = Matched(__pos, __pos);
+                                                                            match __seq_res {
+                                                                                Matched(__pos, r) => Matched(__pos, { Node::new(e, Span::span(l, r)) }),
+                                                                                Failed => Failed,
+                                                                            }
+                                                                        }
+                                                                        Failed => Failed,
+                                                                    }
+                                                                }
+                                                                Failed => Failed,
+                                                            }
+                                                        };
+                                                        match __step_res {
+                                                            Matched(__newpos, __value) => {
+                                                                __repeat_pos = __newpos;
+                                                                __repeat_value.push(__value);
+                                                            }
+                                                            Failed => {
+                                                                break;
+                                                            }
+                                                        }
+                                                    }
+                                                    Matched(__repeat_pos, __repeat_value)
+                                                };
+                                                match __seq_res {
+                                                    Matched(__pos, e) => Matched(__pos, { e }),
+                                                    Failed => Failed,
+                                                }
+                                            };
+                                            match __seq_res {
+                                                Matched(__pos, after) => Matched(__pos, {
+                                                    let mut before = before;
+                                                    before.push(single);
+                                                    before.extend(after);
+                                                    before
+                                                }),
+                                                Failed => Failed,
+                                            }
+                                        }
+                                        Failed => Failed,
+                                    }
+                                }
+                                Failed => Failed,
+                            }
+                        }
+                        Failed => Failed,
+                    }
+                }
+                Failed => Failed,
+            }
+        };
+        match __choice_res {
+            Matched(__pos, __value) => Matched(__pos, __value),
+            Failed => {
+                let __seq_res = {
+                    let __seq_res = {
+                        let mut __repeat_pos = __pos;
+                        let mut __repeat_value = vec![];
+                        loop {
+                            let __pos = __repeat_pos;
+                            let __pos = if __repeat_value.len() > 0 {
+                                let __sep_res = __parse__(__input, __state, __pos, env);
+                                match __sep_res {
+                                    Matched(__newpos, _) => __newpos,
+                                    Failed => break,
+                                }
+                            } else {
+                                __pos
+                            };
+                            let __step_res = {
+                                let __seq_res = Matched(__pos, __pos);
+                                match __seq_res {
+                                    Matched(__pos, l) => {
+                                        let __seq_res = __parse_declaration_specifier0(__input, __state, __pos, env);
+                                        match __seq_res {
+                                            Matched(__pos, e) => {
+                                                let __seq_res = Matched(__pos, __pos);
+                                                match __seq_res {
+                                                    Matched(__pos, r) => Matched(__pos, { Node::new(e, Span::span(l, r)) }),
+                                                    Failed => Failed,
+                                                }
+                                            }
+                                            Failed => Failed,
+                                        }
+                                    }
+                                    Failed => Failed,
+                                }
+                            };
+                            match __step_res {
+                                Matched(__newpos, __value) => {
+                                    __repeat_pos = __newpos;
+                                    __repeat_value.push(__value);
+                                }
+                                Failed => {
+                                    break;
+                                }
+                            }
+                        }
+                        Matched(__repeat_pos, __repeat_value)
+                    };
+                    match __seq_res {
+                        Matched(__pos, e) => Matched(__pos, { e }),
+                        Failed => Failed,
+                    }
+                };
+                match __seq_res {
+                    Matched(__pos, before) => {
+                        let __seq_res = __parse__(__input, __state, __pos, env);
                         match __seq_res {
-                            Matched(__pos, r) => Matched(__pos, { Node::new(e, Span::span(l, r)) }),
+                            Matched(__pos, _) => {
+                                let __seq_res = {
+                                    let __seq_res = Matched(__pos, __pos);
+                                    match __seq_res {
+                                        Matched(__pos, l) => {
+                                            let __seq_res = __parse_declaration_specifier_nonunique_type0(__input, __state, __pos, env);
+                                            match __seq_res {
+                                                Matched(__pos, e) => {
+                                                    let __seq_res = Matched(__pos, __pos);
+                                                    match __seq_res {
+                                                        Matched(__pos, r) => Matched(__pos, { Node::new(e, Span::span(l, r)) }),
+                                                        Failed => Failed,
+                                                    }
+                                                }
+                                                Failed => Failed,
+                                            }
+                                        }
+                                        Failed => Failed,
+                                    }
+                                };
+                                match __seq_res {
+                                    Matched(__pos, single) => {
+                                        let __seq_res = __parse__(__input, __state, __pos, env);
+                                        match __seq_res {
+                                            Matched(__pos, _) => {
+                                                let __seq_res = {
+                                                    let __seq_res = {
+                                                        let mut __repeat_pos = __pos;
+                                                        let mut __repeat_value = vec![];
+                                                        loop {
+                                                            let __pos = __repeat_pos;
+                                                            let __pos = if __repeat_value.len() > 0 {
+                                                                let __sep_res = __parse__(__input, __state, __pos, env);
+                                                                match __sep_res {
+                                                                    Matched(__newpos, _) => __newpos,
+                                                                    Failed => break,
+                                                                }
+                                                            } else {
+                                                                __pos
+                                                            };
+                                                            let __step_res = {
+                                                                let __choice_res = {
+                                                                    let __seq_res = Matched(__pos, __pos);
+                                                                    match __seq_res {
+                                                                        Matched(__pos, l) => {
+                                                                            let __seq_res = __parse_declaration_specifier_nonunique_type0(__input, __state, __pos, env);
+                                                                            match __seq_res {
+                                                                                Matched(__pos, e) => {
+                                                                                    let __seq_res = Matched(__pos, __pos);
+                                                                                    match __seq_res {
+                                                                                        Matched(__pos, r) => Matched(__pos, { Node::new(e, Span::span(l, r)) }),
+                                                                                        Failed => Failed,
+                                                                                    }
+                                                                                }
+                                                                                Failed => Failed,
+                                                                            }
+                                                                        }
+                                                                        Failed => Failed,
+                                                                    }
+                                                                };
+                                                                match __choice_res {
+                                                                    Matched(__pos, __value) => Matched(__pos, __value),
+                                                                    Failed => {
+                                                                        let __seq_res = Matched(__pos, __pos);
+                                                                        match __seq_res {
+                                                                            Matched(__pos, l) => {
+                                                                                let __seq_res = __parse_declaration_specifier0(__input, __state, __pos, env);
+                                                                                match __seq_res {
+                                                                                    Matched(__pos, e) => {
+                                                                                        let __seq_res = Matched(__pos, __pos);
+                                                                                        match __seq_res {
+                                                                                            Matched(__pos, r) => Matched(__pos, { Node::new(e, Span::span(l, r)) }),
+                                                                                            Failed => Failed,
+                                                                                        }
+                                                                                    }
+                                                                                    Failed => Failed,
+                                                                                }
+                                                                            }
+                                                                            Failed => Failed,
+                                                                        }
+                                                                    }
+                                                                }
+                                                            };
+                                                            match __step_res {
+                                                                Matched(__newpos, __value) => {
+                                                                    __repeat_pos = __newpos;
+                                                                    __repeat_value.push(__value);
+                                                                }
+                                                                Failed => {
+                                                                    break;
+                                                                }
+                                                            }
+                                                        }
+                                                        Matched(__repeat_pos, __repeat_value)
+                                                    };
+                                                    match __seq_res {
+                                                        Matched(__pos, e) => Matched(__pos, { e }),
+                                                        Failed => Failed,
+                                                    }
+                                                };
+                                                match __seq_res {
+                                                    Matched(__pos, after) => Matched(__pos, {
+                                                        let mut before = before;
+                                                        before.push(single);
+                                                        before.extend(after);
+                                                        before
+                                                    }),
+                                                    Failed => Failed,
+                                                }
+                                            }
+                                            Failed => Failed,
+                                        }
+                                    }
+                                    Failed => Failed,
+                                }
+                            }
                             Failed => Failed,
                         }
                     }
                     Failed => Failed,
                 }
             }
-            Failed => Failed,
         }
     }
 }
@@ -5162,9 +5444,9 @@ fn __parse_declaration_specifier0<'input>(__input: &'input str, __state: &mut Pa
             Matched(__pos, __value) => Matched(__pos, __value),
             Failed => {
                 let __choice_res = {
-                    let __seq_res = __parse_type_specifier(__input, __state, __pos, env);
+                    let __seq_res = __parse_type_qualifier(__input, __state, __pos, env);
                     match __seq_res {
-                        Matched(__pos, s) => Matched(__pos, { DeclarationSpecifier::TypeSpecifier(s) }),
+                        Matched(__pos, s) => Matched(__pos, { DeclarationSpecifier::TypeQualifier(s) }),
                         Failed => Failed,
                     }
                 };
@@ -5172,9 +5454,9 @@ fn __parse_declaration_specifier0<'input>(__input: &'input str, __state: &mut Pa
                     Matched(__pos, __value) => Matched(__pos, __value),
                     Failed => {
                         let __choice_res = {
-                            let __seq_res = __parse_type_qualifier(__input, __state, __pos, env);
+                            let __seq_res = __parse_function_specifier(__input, __state, __pos, env);
                             match __seq_res {
-                                Matched(__pos, s) => Matched(__pos, { DeclarationSpecifier::TypeQualifier(s) }),
+                                Matched(__pos, s) => Matched(__pos, { DeclarationSpecifier::Function(s) }),
                                 Failed => Failed,
                             }
                         };
@@ -5182,51 +5464,39 @@ fn __parse_declaration_specifier0<'input>(__input: &'input str, __state: &mut Pa
                             Matched(__pos, __value) => Matched(__pos, __value),
                             Failed => {
                                 let __choice_res = {
-                                    let __seq_res = __parse_function_specifier(__input, __state, __pos, env);
+                                    let __seq_res = __parse_alignment_specifier(__input, __state, __pos, env);
                                     match __seq_res {
-                                        Matched(__pos, s) => Matched(__pos, { DeclarationSpecifier::Function(s) }),
+                                        Matched(__pos, s) => Matched(__pos, { DeclarationSpecifier::Alignment(s) }),
                                         Failed => Failed,
                                     }
                                 };
                                 match __choice_res {
                                     Matched(__pos, __value) => Matched(__pos, __value),
                                     Failed => {
-                                        let __choice_res = {
-                                            let __seq_res = __parse_alignment_specifier(__input, __state, __pos, env);
+                                        let __seq_res = {
+                                            let __seq_res = {
+                                                __state.suppress_fail += 1;
+                                                let __assert_res = __parse_gnu_guard(__input, __state, __pos, env);
+                                                __state.suppress_fail -= 1;
+                                                match __assert_res {
+                                                    Matched(_, __value) => Matched(__pos, __value),
+                                                    Failed => Failed,
+                                                }
+                                            };
                                             match __seq_res {
-                                                Matched(__pos, s) => Matched(__pos, { DeclarationSpecifier::Alignment(s) }),
+                                                Matched(__pos, _) => {
+                                                    let __seq_res = __parse_attribute_specifier(__input, __state, __pos, env);
+                                                    match __seq_res {
+                                                        Matched(__pos, e) => Matched(__pos, { e }),
+                                                        Failed => Failed,
+                                                    }
+                                                }
                                                 Failed => Failed,
                                             }
                                         };
-                                        match __choice_res {
-                                            Matched(__pos, __value) => Matched(__pos, __value),
-                                            Failed => {
-                                                let __seq_res = {
-                                                    let __seq_res = {
-                                                        __state.suppress_fail += 1;
-                                                        let __assert_res = __parse_gnu_guard(__input, __state, __pos, env);
-                                                        __state.suppress_fail -= 1;
-                                                        match __assert_res {
-                                                            Matched(_, __value) => Matched(__pos, __value),
-                                                            Failed => Failed,
-                                                        }
-                                                    };
-                                                    match __seq_res {
-                                                        Matched(__pos, _) => {
-                                                            let __seq_res = __parse_attribute_specifier(__input, __state, __pos, env);
-                                                            match __seq_res {
-                                                                Matched(__pos, e) => Matched(__pos, { e }),
-                                                                Failed => Failed,
-                                                            }
-                                                        }
-                                                        Failed => Failed,
-                                                    }
-                                                };
-                                                match __seq_res {
-                                                    Matched(__pos, s) => Matched(__pos, { DeclarationSpecifier::Extension(s) }),
-                                                    Failed => Failed,
-                                                }
-                                            }
+                                        match __seq_res {
+                                            Matched(__pos, s) => Matched(__pos, { DeclarationSpecifier::Extension(s) }),
+                                            Failed => Failed,
                                         }
                                     }
                                 }
@@ -5235,6 +5505,64 @@ fn __parse_declaration_specifier0<'input>(__input: &'input str, __state: &mut Pa
                     }
                 }
             }
+        }
+    }
+}
+
+fn __parse_declaration_specifier_unique_type0<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<DeclarationSpecifier> {
+    #![allow(non_snake_case, unused)]
+    {
+        let __seq_res = {
+            let __seq_res = Matched(__pos, __pos);
+            match __seq_res {
+                Matched(__pos, l) => {
+                    let __seq_res = __parse_type_specifier_unique(__input, __state, __pos, env);
+                    match __seq_res {
+                        Matched(__pos, e) => {
+                            let __seq_res = Matched(__pos, __pos);
+                            match __seq_res {
+                                Matched(__pos, r) => Matched(__pos, { Node::new(e, Span::span(l, r)) }),
+                                Failed => Failed,
+                            }
+                        }
+                        Failed => Failed,
+                    }
+                }
+                Failed => Failed,
+            }
+        };
+        match __seq_res {
+            Matched(__pos, s) => Matched(__pos, { DeclarationSpecifier::TypeSpecifier(s) }),
+            Failed => Failed,
+        }
+    }
+}
+
+fn __parse_declaration_specifier_nonunique_type0<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<DeclarationSpecifier> {
+    #![allow(non_snake_case, unused)]
+    {
+        let __seq_res = {
+            let __seq_res = Matched(__pos, __pos);
+            match __seq_res {
+                Matched(__pos, l) => {
+                    let __seq_res = __parse_type_specifier_nonunique(__input, __state, __pos, env);
+                    match __seq_res {
+                        Matched(__pos, e) => {
+                            let __seq_res = Matched(__pos, __pos);
+                            match __seq_res {
+                                Matched(__pos, r) => Matched(__pos, { Node::new(e, Span::span(l, r)) }),
+                                Failed => Failed,
+                            }
+                        }
+                        Failed => Failed,
+                    }
+                }
+                Failed => Failed,
+            }
+        };
+        match __seq_res {
+            Matched(__pos, s) => Matched(__pos, { DeclarationSpecifier::TypeSpecifier(s) }),
+            Failed => Failed,
         }
     }
 }
@@ -5659,30 +5987,7 @@ fn __parse_storage_class_specifier0<'input>(__input: &'input str, __state: &mut 
     }
 }
 
-fn __parse_type_specifier<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Node<TypeSpecifier>> {
-    #![allow(non_snake_case, unused)]
-    {
-        let __seq_res = Matched(__pos, __pos);
-        match __seq_res {
-            Matched(__pos, l) => {
-                let __seq_res = __parse_type_specifier0(__input, __state, __pos, env);
-                match __seq_res {
-                    Matched(__pos, e) => {
-                        let __seq_res = Matched(__pos, __pos);
-                        match __seq_res {
-                            Matched(__pos, r) => Matched(__pos, { Node::new(e, Span::span(l, r)) }),
-                            Failed => Failed,
-                        }
-                    }
-                    Failed => Failed,
-                }
-            }
-            Failed => Failed,
-        }
-    }
-}
-
-fn __parse_type_specifier0<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<TypeSpecifier> {
+fn __parse_type_specifier_unique<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<TypeSpecifier> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -5732,7 +6037,7 @@ fn __parse_type_specifier0<'input>(__input: &'input str, __state: &mut ParseStat
                     let __seq_res = {
                         __state.suppress_fail += 1;
                         let res = {
-                            let __seq_res = slice_eq(__input, __state, __pos, "char");
+                            let __seq_res = slice_eq(__input, __state, __pos, "_Bool");
                             match __seq_res {
                                 Matched(__pos, e) => {
                                     let __seq_res = {
@@ -5764,7 +6069,7 @@ fn __parse_type_specifier0<'input>(__input: &'input str, __state: &mut ParseStat
                         res
                     };
                     match __seq_res {
-                        Matched(__pos, _) => Matched(__pos, { TypeSpecifier::Char }),
+                        Matched(__pos, _) => Matched(__pos, { TypeSpecifier::Bool }),
                         Failed => Failed,
                     }
                 };
@@ -5775,7 +6080,7 @@ fn __parse_type_specifier0<'input>(__input: &'input str, __state: &mut ParseStat
                             let __seq_res = {
                                 __state.suppress_fail += 1;
                                 let res = {
-                                    let __seq_res = slice_eq(__input, __state, __pos, "short");
+                                    let __seq_res = slice_eq(__input, __state, __pos, "_Atomic");
                                     match __seq_res {
                                         Matched(__pos, e) => {
                                             let __seq_res = {
@@ -5807,7 +6112,249 @@ fn __parse_type_specifier0<'input>(__input: &'input str, __state: &mut ParseStat
                                 res
                             };
                             match __seq_res {
-                                Matched(__pos, _) => Matched(__pos, { TypeSpecifier::Short }),
+                                Matched(__pos, _) => {
+                                    let __seq_res = __parse__(__input, __state, __pos, env);
+                                    match __seq_res {
+                                        Matched(__pos, _) => {
+                                            let __seq_res = slice_eq(__input, __state, __pos, "(");
+                                            match __seq_res {
+                                                Matched(__pos, _) => {
+                                                    let __seq_res = __parse__(__input, __state, __pos, env);
+                                                    match __seq_res {
+                                                        Matched(__pos, _) => {
+                                                            let __seq_res = __parse_type_name(__input, __state, __pos, env);
+                                                            match __seq_res {
+                                                                Matched(__pos, t) => {
+                                                                    let __seq_res = __parse__(__input, __state, __pos, env);
+                                                                    match __seq_res {
+                                                                        Matched(__pos, _) => {
+                                                                            let __seq_res = slice_eq(__input, __state, __pos, ")");
+                                                                            match __seq_res {
+                                                                                Matched(__pos, _) => Matched(__pos, { TypeSpecifier::Atomic(t) }),
+                                                                                Failed => Failed,
+                                                                            }
+                                                                        }
+                                                                        Failed => Failed,
+                                                                    }
+                                                                }
+                                                                Failed => Failed,
+                                                            }
+                                                        }
+                                                        Failed => Failed,
+                                                    }
+                                                }
+                                                Failed => Failed,
+                                            }
+                                        }
+                                        Failed => Failed,
+                                    }
+                                }
+                                Failed => Failed,
+                            }
+                        };
+                        match __choice_res {
+                            Matched(__pos, __value) => Matched(__pos, __value),
+                            Failed => {
+                                let __choice_res = {
+                                    let __seq_res = {
+                                        let __seq_res = Matched(__pos, __pos);
+                                        match __seq_res {
+                                            Matched(__pos, l) => {
+                                                let __seq_res = __parse_struct_or_union_specifier(__input, __state, __pos, env);
+                                                match __seq_res {
+                                                    Matched(__pos, e) => {
+                                                        let __seq_res = Matched(__pos, __pos);
+                                                        match __seq_res {
+                                                            Matched(__pos, r) => Matched(__pos, { Node::new(e, Span::span(l, r)) }),
+                                                            Failed => Failed,
+                                                        }
+                                                    }
+                                                    Failed => Failed,
+                                                }
+                                            }
+                                            Failed => Failed,
+                                        }
+                                    };
+                                    match __seq_res {
+                                        Matched(__pos, s) => Matched(__pos, { TypeSpecifier::Struct(s) }),
+                                        Failed => Failed,
+                                    }
+                                };
+                                match __choice_res {
+                                    Matched(__pos, __value) => Matched(__pos, __value),
+                                    Failed => {
+                                        let __choice_res = {
+                                            let __seq_res = {
+                                                let __seq_res = Matched(__pos, __pos);
+                                                match __seq_res {
+                                                    Matched(__pos, l) => {
+                                                        let __seq_res = __parse_enum_specifier(__input, __state, __pos, env);
+                                                        match __seq_res {
+                                                            Matched(__pos, e) => {
+                                                                let __seq_res = Matched(__pos, __pos);
+                                                                match __seq_res {
+                                                                    Matched(__pos, r) => Matched(__pos, { Node::new(e, Span::span(l, r)) }),
+                                                                    Failed => Failed,
+                                                                }
+                                                            }
+                                                            Failed => Failed,
+                                                        }
+                                                    }
+                                                    Failed => Failed,
+                                                }
+                                            };
+                                            match __seq_res {
+                                                Matched(__pos, e) => Matched(__pos, { TypeSpecifier::Enum(e) }),
+                                                Failed => Failed,
+                                            }
+                                        };
+                                        match __choice_res {
+                                            Matched(__pos, __value) => Matched(__pos, __value),
+                                            Failed => {
+                                                let __seq_res = __parse_typedef_name(__input, __state, __pos, env);
+                                                match __seq_res {
+                                                    Matched(__pos, t) => Matched(__pos, { TypeSpecifier::TypedefName(t) }),
+                                                    Failed => Failed,
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn __parse_type_specifier_nonunique<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<TypeSpecifier> {
+    #![allow(non_snake_case, unused)]
+    {
+        let __choice_res = {
+            let __seq_res = {
+                __state.suppress_fail += 1;
+                let res = {
+                    let __seq_res = slice_eq(__input, __state, __pos, "char");
+                    match __seq_res {
+                        Matched(__pos, e) => {
+                            let __seq_res = {
+                                __state.suppress_fail += 1;
+                                let __assert_res = if __input.len() > __pos {
+                                    let (__ch, __next) = char_range_at(__input, __pos);
+                                    match __ch {
+                                        '_' | 'a'...'z' | 'A'...'Z' | '0'...'9' => Matched(__next, ()),
+                                        _ => __state.mark_failure(__pos, "[_a-zA-Z0-9]"),
+                                    }
+                                } else {
+                                    __state.mark_failure(__pos, "[_a-zA-Z0-9]")
+                                };
+                                __state.suppress_fail -= 1;
+                                match __assert_res {
+                                    Failed => Matched(__pos, ()),
+                                    Matched(..) => Failed,
+                                }
+                            };
+                            match __seq_res {
+                                Matched(__pos, _) => Matched(__pos, { e }),
+                                Failed => Failed,
+                            }
+                        }
+                        Failed => Failed,
+                    }
+                };
+                __state.suppress_fail -= 1;
+                res
+            };
+            match __seq_res {
+                Matched(__pos, _) => Matched(__pos, { TypeSpecifier::Char }),
+                Failed => Failed,
+            }
+        };
+        match __choice_res {
+            Matched(__pos, __value) => Matched(__pos, __value),
+            Failed => {
+                let __choice_res = {
+                    let __seq_res = {
+                        __state.suppress_fail += 1;
+                        let res = {
+                            let __seq_res = slice_eq(__input, __state, __pos, "short");
+                            match __seq_res {
+                                Matched(__pos, e) => {
+                                    let __seq_res = {
+                                        __state.suppress_fail += 1;
+                                        let __assert_res = if __input.len() > __pos {
+                                            let (__ch, __next) = char_range_at(__input, __pos);
+                                            match __ch {
+                                                '_' | 'a'...'z' | 'A'...'Z' | '0'...'9' => Matched(__next, ()),
+                                                _ => __state.mark_failure(__pos, "[_a-zA-Z0-9]"),
+                                            }
+                                        } else {
+                                            __state.mark_failure(__pos, "[_a-zA-Z0-9]")
+                                        };
+                                        __state.suppress_fail -= 1;
+                                        match __assert_res {
+                                            Failed => Matched(__pos, ()),
+                                            Matched(..) => Failed,
+                                        }
+                                    };
+                                    match __seq_res {
+                                        Matched(__pos, _) => Matched(__pos, { e }),
+                                        Failed => Failed,
+                                    }
+                                }
+                                Failed => Failed,
+                            }
+                        };
+                        __state.suppress_fail -= 1;
+                        res
+                    };
+                    match __seq_res {
+                        Matched(__pos, _) => Matched(__pos, { TypeSpecifier::Short }),
+                        Failed => Failed,
+                    }
+                };
+                match __choice_res {
+                    Matched(__pos, __value) => Matched(__pos, __value),
+                    Failed => {
+                        let __choice_res = {
+                            let __seq_res = {
+                                __state.suppress_fail += 1;
+                                let res = {
+                                    let __seq_res = slice_eq(__input, __state, __pos, "int");
+                                    match __seq_res {
+                                        Matched(__pos, e) => {
+                                            let __seq_res = {
+                                                __state.suppress_fail += 1;
+                                                let __assert_res = if __input.len() > __pos {
+                                                    let (__ch, __next) = char_range_at(__input, __pos);
+                                                    match __ch {
+                                                        '_' | 'a'...'z' | 'A'...'Z' | '0'...'9' => Matched(__next, ()),
+                                                        _ => __state.mark_failure(__pos, "[_a-zA-Z0-9]"),
+                                                    }
+                                                } else {
+                                                    __state.mark_failure(__pos, "[_a-zA-Z0-9]")
+                                                };
+                                                __state.suppress_fail -= 1;
+                                                match __assert_res {
+                                                    Failed => Matched(__pos, ()),
+                                                    Matched(..) => Failed,
+                                                }
+                                            };
+                                            match __seq_res {
+                                                Matched(__pos, _) => Matched(__pos, { e }),
+                                                Failed => Failed,
+                                            }
+                                        }
+                                        Failed => Failed,
+                                    }
+                                };
+                                __state.suppress_fail -= 1;
+                                res
+                            };
+                            match __seq_res {
+                                Matched(__pos, _) => Matched(__pos, { TypeSpecifier::Int }),
                                 Failed => Failed,
                             }
                         };
@@ -5818,7 +6365,7 @@ fn __parse_type_specifier0<'input>(__input: &'input str, __state: &mut ParseStat
                                     let __seq_res = {
                                         __state.suppress_fail += 1;
                                         let res = {
-                                            let __seq_res = slice_eq(__input, __state, __pos, "int");
+                                            let __seq_res = slice_eq(__input, __state, __pos, "long");
                                             match __seq_res {
                                                 Matched(__pos, e) => {
                                                     let __seq_res = {
@@ -5850,7 +6397,7 @@ fn __parse_type_specifier0<'input>(__input: &'input str, __state: &mut ParseStat
                                         res
                                     };
                                     match __seq_res {
-                                        Matched(__pos, _) => Matched(__pos, { TypeSpecifier::Int }),
+                                        Matched(__pos, _) => Matched(__pos, { TypeSpecifier::Long }),
                                         Failed => Failed,
                                     }
                                 };
@@ -5861,7 +6408,7 @@ fn __parse_type_specifier0<'input>(__input: &'input str, __state: &mut ParseStat
                                             let __seq_res = {
                                                 __state.suppress_fail += 1;
                                                 let res = {
-                                                    let __seq_res = slice_eq(__input, __state, __pos, "long");
+                                                    let __seq_res = slice_eq(__input, __state, __pos, "float");
                                                     match __seq_res {
                                                         Matched(__pos, e) => {
                                                             let __seq_res = {
@@ -5893,7 +6440,7 @@ fn __parse_type_specifier0<'input>(__input: &'input str, __state: &mut ParseStat
                                                 res
                                             };
                                             match __seq_res {
-                                                Matched(__pos, _) => Matched(__pos, { TypeSpecifier::Long }),
+                                                Matched(__pos, _) => Matched(__pos, { TypeSpecifier::Float }),
                                                 Failed => Failed,
                                             }
                                         };
@@ -5904,7 +6451,7 @@ fn __parse_type_specifier0<'input>(__input: &'input str, __state: &mut ParseStat
                                                     let __seq_res = {
                                                         __state.suppress_fail += 1;
                                                         let res = {
-                                                            let __seq_res = slice_eq(__input, __state, __pos, "float");
+                                                            let __seq_res = slice_eq(__input, __state, __pos, "double");
                                                             match __seq_res {
                                                                 Matched(__pos, e) => {
                                                                     let __seq_res = {
@@ -5936,7 +6483,7 @@ fn __parse_type_specifier0<'input>(__input: &'input str, __state: &mut ParseStat
                                                         res
                                                     };
                                                     match __seq_res {
-                                                        Matched(__pos, _) => Matched(__pos, { TypeSpecifier::Float }),
+                                                        Matched(__pos, _) => Matched(__pos, { TypeSpecifier::Double }),
                                                         Failed => Failed,
                                                     }
                                                 };
@@ -5947,7 +6494,42 @@ fn __parse_type_specifier0<'input>(__input: &'input str, __state: &mut ParseStat
                                                             let __seq_res = {
                                                                 __state.suppress_fail += 1;
                                                                 let res = {
-                                                                    let __seq_res = slice_eq(__input, __state, __pos, "double");
+                                                                    let __seq_res = {
+                                                                        let __choice_res = slice_eq(__input, __state, __pos, "signed");
+                                                                        match __choice_res {
+                                                                            Matched(__pos, __value) => Matched(__pos, __value),
+                                                                            Failed => {
+                                                                                let __seq_res = {
+                                                                                    __state.suppress_fail += 1;
+                                                                                    let __assert_res = __parse_gnu_guard(__input, __state, __pos, env);
+                                                                                    __state.suppress_fail -= 1;
+                                                                                    match __assert_res {
+                                                                                        Matched(_, __value) => Matched(__pos, __value),
+                                                                                        Failed => Failed,
+                                                                                    }
+                                                                                };
+                                                                                match __seq_res {
+                                                                                    Matched(__pos, _) => {
+                                                                                        let __seq_res = {
+                                                                                            let __seq_res = slice_eq(__input, __state, __pos, "__signed");
+                                                                                            match __seq_res {
+                                                                                                Matched(__pos, _) => match slice_eq(__input, __state, __pos, "__") {
+                                                                                                    Matched(__newpos, _) => Matched(__newpos, ()),
+                                                                                                    Failed => Matched(__pos, ()),
+                                                                                                },
+                                                                                                Failed => Failed,
+                                                                                            }
+                                                                                        };
+                                                                                        match __seq_res {
+                                                                                            Matched(__pos, e) => Matched(__pos, { e }),
+                                                                                            Failed => Failed,
+                                                                                        }
+                                                                                    }
+                                                                                    Failed => Failed,
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    };
                                                                     match __seq_res {
                                                                         Matched(__pos, e) => {
                                                                             let __seq_res = {
@@ -5979,7 +6561,7 @@ fn __parse_type_specifier0<'input>(__input: &'input str, __state: &mut ParseStat
                                                                 res
                                                             };
                                                             match __seq_res {
-                                                                Matched(__pos, _) => Matched(__pos, { TypeSpecifier::Double }),
+                                                                Matched(__pos, _) => Matched(__pos, { TypeSpecifier::Signed }),
                                                                 Failed => Failed,
                                                             }
                                                         };
@@ -5990,42 +6572,7 @@ fn __parse_type_specifier0<'input>(__input: &'input str, __state: &mut ParseStat
                                                                     let __seq_res = {
                                                                         __state.suppress_fail += 1;
                                                                         let res = {
-                                                                            let __seq_res = {
-                                                                                let __choice_res = slice_eq(__input, __state, __pos, "signed");
-                                                                                match __choice_res {
-                                                                                    Matched(__pos, __value) => Matched(__pos, __value),
-                                                                                    Failed => {
-                                                                                        let __seq_res = {
-                                                                                            __state.suppress_fail += 1;
-                                                                                            let __assert_res = __parse_gnu_guard(__input, __state, __pos, env);
-                                                                                            __state.suppress_fail -= 1;
-                                                                                            match __assert_res {
-                                                                                                Matched(_, __value) => Matched(__pos, __value),
-                                                                                                Failed => Failed,
-                                                                                            }
-                                                                                        };
-                                                                                        match __seq_res {
-                                                                                            Matched(__pos, _) => {
-                                                                                                let __seq_res = {
-                                                                                                    let __seq_res = slice_eq(__input, __state, __pos, "__signed");
-                                                                                                    match __seq_res {
-                                                                                                        Matched(__pos, _) => match slice_eq(__input, __state, __pos, "__") {
-                                                                                                            Matched(__newpos, _) => Matched(__newpos, ()),
-                                                                                                            Failed => Matched(__pos, ()),
-                                                                                                        },
-                                                                                                        Failed => Failed,
-                                                                                                    }
-                                                                                                };
-                                                                                                match __seq_res {
-                                                                                                    Matched(__pos, e) => Matched(__pos, { e }),
-                                                                                                    Failed => Failed,
-                                                                                                }
-                                                                                            }
-                                                                                            Failed => Failed,
-                                                                                        }
-                                                                                    }
-                                                                                }
-                                                                            };
+                                                                            let __seq_res = slice_eq(__input, __state, __pos, "unsigned");
                                                                             match __seq_res {
                                                                                 Matched(__pos, e) => {
                                                                                     let __seq_res = {
@@ -6057,7 +6604,7 @@ fn __parse_type_specifier0<'input>(__input: &'input str, __state: &mut ParseStat
                                                                         res
                                                                     };
                                                                     match __seq_res {
-                                                                        Matched(__pos, _) => Matched(__pos, { TypeSpecifier::Signed }),
+                                                                        Matched(__pos, _) => Matched(__pos, { TypeSpecifier::Unsigned }),
                                                                         Failed => Failed,
                                                                     }
                                                                 };
@@ -6068,7 +6615,42 @@ fn __parse_type_specifier0<'input>(__input: &'input str, __state: &mut ParseStat
                                                                             let __seq_res = {
                                                                                 __state.suppress_fail += 1;
                                                                                 let res = {
-                                                                                    let __seq_res = slice_eq(__input, __state, __pos, "unsigned");
+                                                                                    let __seq_res = {
+                                                                                        let __choice_res = slice_eq(__input, __state, __pos, "_Complex");
+                                                                                        match __choice_res {
+                                                                                            Matched(__pos, __value) => Matched(__pos, __value),
+                                                                                            Failed => {
+                                                                                                let __seq_res = {
+                                                                                                    __state.suppress_fail += 1;
+                                                                                                    let __assert_res = __parse_gnu_guard(__input, __state, __pos, env);
+                                                                                                    __state.suppress_fail -= 1;
+                                                                                                    match __assert_res {
+                                                                                                        Matched(_, __value) => Matched(__pos, __value),
+                                                                                                        Failed => Failed,
+                                                                                                    }
+                                                                                                };
+                                                                                                match __seq_res {
+                                                                                                    Matched(__pos, _) => {
+                                                                                                        let __seq_res = {
+                                                                                                            let __seq_res = slice_eq(__input, __state, __pos, "__complex");
+                                                                                                            match __seq_res {
+                                                                                                                Matched(__pos, _) => match slice_eq(__input, __state, __pos, "__") {
+                                                                                                                    Matched(__newpos, _) => Matched(__newpos, ()),
+                                                                                                                    Failed => Matched(__pos, ()),
+                                                                                                                },
+                                                                                                                Failed => Failed,
+                                                                                                            }
+                                                                                                        };
+                                                                                                        match __seq_res {
+                                                                                                            Matched(__pos, e) => Matched(__pos, { e }),
+                                                                                                            Failed => Failed,
+                                                                                                        }
+                                                                                                    }
+                                                                                                    Failed => Failed,
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    };
                                                                                     match __seq_res {
                                                                                         Matched(__pos, e) => {
                                                                                             let __seq_res = {
@@ -6100,7 +6682,7 @@ fn __parse_type_specifier0<'input>(__input: &'input str, __state: &mut ParseStat
                                                                                 res
                                                                             };
                                                                             match __seq_res {
-                                                                                Matched(__pos, _) => Matched(__pos, { TypeSpecifier::Unsigned }),
+                                                                                Matched(__pos, _) => Matched(__pos, { TypeSpecifier::Complex }),
                                                                                 Failed => Failed,
                                                                             }
                                                                         };
@@ -6111,7 +6693,7 @@ fn __parse_type_specifier0<'input>(__input: &'input str, __state: &mut ParseStat
                                                                                     let __seq_res = {
                                                                                         __state.suppress_fail += 1;
                                                                                         let res = {
-                                                                                            let __seq_res = slice_eq(__input, __state, __pos, "_Bool");
+                                                                                            let __seq_res = __parse_ts18661_float_type_specifier(__input, __state, __pos, env);
                                                                                             match __seq_res {
                                                                                                 Matched(__pos, e) => {
                                                                                                     let __seq_res = {
@@ -6143,309 +6725,31 @@ fn __parse_type_specifier0<'input>(__input: &'input str, __state: &mut ParseStat
                                                                                         res
                                                                                     };
                                                                                     match __seq_res {
-                                                                                        Matched(__pos, _) => Matched(__pos, { TypeSpecifier::Bool }),
+                                                                                        Matched(__pos, t) => Matched(__pos, { TypeSpecifier::TS18661Float(t) }),
                                                                                         Failed => Failed,
                                                                                     }
                                                                                 };
                                                                                 match __choice_res {
                                                                                     Matched(__pos, __value) => Matched(__pos, __value),
                                                                                     Failed => {
-                                                                                        let __choice_res = {
-                                                                                            let __seq_res = {
-                                                                                                __state.suppress_fail += 1;
-                                                                                                let res = {
-                                                                                                    let __seq_res = {
-                                                                                                        let __choice_res = slice_eq(__input, __state, __pos, "_Complex");
-                                                                                                        match __choice_res {
-                                                                                                            Matched(__pos, __value) => Matched(__pos, __value),
-                                                                                                            Failed => {
-                                                                                                                let __seq_res = {
-                                                                                                                    __state.suppress_fail += 1;
-                                                                                                                    let __assert_res = __parse_gnu_guard(__input, __state, __pos, env);
-                                                                                                                    __state.suppress_fail -= 1;
-                                                                                                                    match __assert_res {
-                                                                                                                        Matched(_, __value) => Matched(__pos, __value),
-                                                                                                                        Failed => Failed,
-                                                                                                                    }
-                                                                                                                };
-                                                                                                                match __seq_res {
-                                                                                                                    Matched(__pos, _) => {
-                                                                                                                        let __seq_res = {
-                                                                                                                            let __seq_res = slice_eq(__input, __state, __pos, "__complex");
-                                                                                                                            match __seq_res {
-                                                                                                                                Matched(__pos, _) => match slice_eq(__input, __state, __pos, "__") {
-                                                                                                                                    Matched(__newpos, _) => Matched(__newpos, ()),
-                                                                                                                                    Failed => Matched(__pos, ()),
-                                                                                                                                },
-                                                                                                                                Failed => Failed,
-                                                                                                                            }
-                                                                                                                        };
-                                                                                                                        match __seq_res {
-                                                                                                                            Matched(__pos, e) => Matched(__pos, { e }),
-                                                                                                                            Failed => Failed,
-                                                                                                                        }
-                                                                                                                    }
-                                                                                                                    Failed => Failed,
-                                                                                                                }
-                                                                                                            }
-                                                                                                        }
-                                                                                                    };
-                                                                                                    match __seq_res {
-                                                                                                        Matched(__pos, e) => {
-                                                                                                            let __seq_res = {
-                                                                                                                __state.suppress_fail += 1;
-                                                                                                                let __assert_res = if __input.len() > __pos {
-                                                                                                                    let (__ch, __next) = char_range_at(__input, __pos);
-                                                                                                                    match __ch {
-                                                                                                                        '_' | 'a'...'z' | 'A'...'Z' | '0'...'9' => Matched(__next, ()),
-                                                                                                                        _ => __state.mark_failure(__pos, "[_a-zA-Z0-9]"),
-                                                                                                                    }
-                                                                                                                } else {
-                                                                                                                    __state.mark_failure(__pos, "[_a-zA-Z0-9]")
-                                                                                                                };
-                                                                                                                __state.suppress_fail -= 1;
-                                                                                                                match __assert_res {
-                                                                                                                    Failed => Matched(__pos, ()),
-                                                                                                                    Matched(..) => Failed,
-                                                                                                                }
-                                                                                                            };
-                                                                                                            match __seq_res {
-                                                                                                                Matched(__pos, _) => Matched(__pos, { e }),
-                                                                                                                Failed => Failed,
-                                                                                                            }
-                                                                                                        }
-                                                                                                        Failed => Failed,
-                                                                                                    }
-                                                                                                };
-                                                                                                __state.suppress_fail -= 1;
-                                                                                                res
-                                                                                            };
-                                                                                            match __seq_res {
-                                                                                                Matched(__pos, _) => Matched(__pos, { TypeSpecifier::Complex }),
+                                                                                        let __seq_res = {
+                                                                                            __state.suppress_fail += 1;
+                                                                                            let __assert_res = __parse_gnu_guard(__input, __state, __pos, env);
+                                                                                            __state.suppress_fail -= 1;
+                                                                                            match __assert_res {
+                                                                                                Matched(_, __value) => Matched(__pos, __value),
                                                                                                 Failed => Failed,
                                                                                             }
                                                                                         };
-                                                                                        match __choice_res {
-                                                                                            Matched(__pos, __value) => Matched(__pos, __value),
-                                                                                            Failed => {
-                                                                                                let __choice_res = {
-                                                                                                    let __seq_res = {
-                                                                                                        __state.suppress_fail += 1;
-                                                                                                        let res = {
-                                                                                                            let __seq_res = slice_eq(__input, __state, __pos, "_Atomic");
-                                                                                                            match __seq_res {
-                                                                                                                Matched(__pos, e) => {
-                                                                                                                    let __seq_res = {
-                                                                                                                        __state.suppress_fail += 1;
-                                                                                                                        let __assert_res = if __input.len() > __pos {
-                                                                                                                            let (__ch, __next) = char_range_at(__input, __pos);
-                                                                                                                            match __ch {
-                                                                                                                                '_' | 'a'...'z' | 'A'...'Z' | '0'...'9' => Matched(__next, ()),
-                                                                                                                                _ => __state.mark_failure(__pos, "[_a-zA-Z0-9]"),
-                                                                                                                            }
-                                                                                                                        } else {
-                                                                                                                            __state.mark_failure(__pos, "[_a-zA-Z0-9]")
-                                                                                                                        };
-                                                                                                                        __state.suppress_fail -= 1;
-                                                                                                                        match __assert_res {
-                                                                                                                            Failed => Matched(__pos, ()),
-                                                                                                                            Matched(..) => Failed,
-                                                                                                                        }
-                                                                                                                    };
-                                                                                                                    match __seq_res {
-                                                                                                                        Matched(__pos, _) => Matched(__pos, { e }),
-                                                                                                                        Failed => Failed,
-                                                                                                                    }
-                                                                                                                }
-                                                                                                                Failed => Failed,
-                                                                                                            }
-                                                                                                        };
-                                                                                                        __state.suppress_fail -= 1;
-                                                                                                        res
-                                                                                                    };
-                                                                                                    match __seq_res {
-                                                                                                        Matched(__pos, _) => {
-                                                                                                            let __seq_res = __parse__(__input, __state, __pos, env);
-                                                                                                            match __seq_res {
-                                                                                                                Matched(__pos, _) => {
-                                                                                                                    let __seq_res = slice_eq(__input, __state, __pos, "(");
-                                                                                                                    match __seq_res {
-                                                                                                                        Matched(__pos, _) => {
-                                                                                                                            let __seq_res = __parse__(__input, __state, __pos, env);
-                                                                                                                            match __seq_res {
-                                                                                                                                Matched(__pos, _) => {
-                                                                                                                                    let __seq_res = __parse_type_name(__input, __state, __pos, env);
-                                                                                                                                    match __seq_res {
-                                                                                                                                        Matched(__pos, t) => {
-                                                                                                                                            let __seq_res = __parse__(__input, __state, __pos, env);
-                                                                                                                                            match __seq_res {
-                                                                                                                                                Matched(__pos, _) => {
-                                                                                                                                                    let __seq_res = slice_eq(__input, __state, __pos, ")");
-                                                                                                                                                    match __seq_res {
-                                                                                                                                                        Matched(__pos, _) => Matched(__pos, { TypeSpecifier::Atomic(t) }),
-                                                                                                                                                        Failed => Failed,
-                                                                                                                                                    }
-                                                                                                                                                }
-                                                                                                                                                Failed => Failed,
-                                                                                                                                            }
-                                                                                                                                        }
-                                                                                                                                        Failed => Failed,
-                                                                                                                                    }
-                                                                                                                                }
-                                                                                                                                Failed => Failed,
-                                                                                                                            }
-                                                                                                                        }
-                                                                                                                        Failed => Failed,
-                                                                                                                    }
-                                                                                                                }
-                                                                                                                Failed => Failed,
-                                                                                                            }
-                                                                                                        }
-                                                                                                        Failed => Failed,
-                                                                                                    }
-                                                                                                };
-                                                                                                match __choice_res {
-                                                                                                    Matched(__pos, __value) => Matched(__pos, __value),
-                                                                                                    Failed => {
-                                                                                                        let __choice_res = {
-                                                                                                            let __seq_res = {
-                                                                                                                __state.suppress_fail += 1;
-                                                                                                                let res = {
-                                                                                                                    let __seq_res = __parse_ts18661_float_type_specifier(__input, __state, __pos, env);
-                                                                                                                    match __seq_res {
-                                                                                                                        Matched(__pos, e) => {
-                                                                                                                            let __seq_res = {
-                                                                                                                                __state.suppress_fail += 1;
-                                                                                                                                let __assert_res = if __input.len() > __pos {
-                                                                                                                                    let (__ch, __next) = char_range_at(__input, __pos);
-                                                                                                                                    match __ch {
-                                                                                                                                        '_' | 'a'...'z' | 'A'...'Z' | '0'...'9' => Matched(__next, ()),
-                                                                                                                                        _ => __state.mark_failure(__pos, "[_a-zA-Z0-9]"),
-                                                                                                                                    }
-                                                                                                                                } else {
-                                                                                                                                    __state.mark_failure(__pos, "[_a-zA-Z0-9]")
-                                                                                                                                };
-                                                                                                                                __state.suppress_fail -= 1;
-                                                                                                                                match __assert_res {
-                                                                                                                                    Failed => Matched(__pos, ()),
-                                                                                                                                    Matched(..) => Failed,
-                                                                                                                                }
-                                                                                                                            };
-                                                                                                                            match __seq_res {
-                                                                                                                                Matched(__pos, _) => Matched(__pos, { e }),
-                                                                                                                                Failed => Failed,
-                                                                                                                            }
-                                                                                                                        }
-                                                                                                                        Failed => Failed,
-                                                                                                                    }
-                                                                                                                };
-                                                                                                                __state.suppress_fail -= 1;
-                                                                                                                res
-                                                                                                            };
-                                                                                                            match __seq_res {
-                                                                                                                Matched(__pos, t) => Matched(__pos, { TypeSpecifier::TS18661Float(t) }),
-                                                                                                                Failed => Failed,
-                                                                                                            }
-                                                                                                        };
-                                                                                                        match __choice_res {
-                                                                                                            Matched(__pos, __value) => Matched(__pos, __value),
-                                                                                                            Failed => {
-                                                                                                                let __choice_res = {
-                                                                                                                    let __seq_res = __parse_typedef_name(__input, __state, __pos, env);
-                                                                                                                    match __seq_res {
-                                                                                                                        Matched(__pos, t) => Matched(__pos, { TypeSpecifier::TypedefName(t) }),
-                                                                                                                        Failed => Failed,
-                                                                                                                    }
-                                                                                                                };
-                                                                                                                match __choice_res {
-                                                                                                                    Matched(__pos, __value) => Matched(__pos, __value),
-                                                                                                                    Failed => {
-                                                                                                                        let __choice_res = {
-                                                                                                                            let __seq_res = {
-                                                                                                                                let __seq_res = Matched(__pos, __pos);
-                                                                                                                                match __seq_res {
-                                                                                                                                    Matched(__pos, l) => {
-                                                                                                                                        let __seq_res = __parse_struct_or_union_specifier(__input, __state, __pos, env);
-                                                                                                                                        match __seq_res {
-                                                                                                                                            Matched(__pos, e) => {
-                                                                                                                                                let __seq_res = Matched(__pos, __pos);
-                                                                                                                                                match __seq_res {
-                                                                                                                                                    Matched(__pos, r) => Matched(__pos, { Node::new(e, Span::span(l, r)) }),
-                                                                                                                                                    Failed => Failed,
-                                                                                                                                                }
-                                                                                                                                            }
-                                                                                                                                            Failed => Failed,
-                                                                                                                                        }
-                                                                                                                                    }
-                                                                                                                                    Failed => Failed,
-                                                                                                                                }
-                                                                                                                            };
-                                                                                                                            match __seq_res {
-                                                                                                                                Matched(__pos, s) => Matched(__pos, { TypeSpecifier::Struct(s) }),
-                                                                                                                                Failed => Failed,
-                                                                                                                            }
-                                                                                                                        };
-                                                                                                                        match __choice_res {
-                                                                                                                            Matched(__pos, __value) => Matched(__pos, __value),
-                                                                                                                            Failed => {
-                                                                                                                                let __choice_res = {
-                                                                                                                                    let __seq_res = {
-                                                                                                                                        let __seq_res = Matched(__pos, __pos);
-                                                                                                                                        match __seq_res {
-                                                                                                                                            Matched(__pos, l) => {
-                                                                                                                                                let __seq_res = __parse_enum_specifier(__input, __state, __pos, env);
-                                                                                                                                                match __seq_res {
-                                                                                                                                                    Matched(__pos, e) => {
-                                                                                                                                                        let __seq_res = Matched(__pos, __pos);
-                                                                                                                                                        match __seq_res {
-                                                                                                                                                            Matched(__pos, r) => Matched(__pos, { Node::new(e, Span::span(l, r)) }),
-                                                                                                                                                            Failed => Failed,
-                                                                                                                                                        }
-                                                                                                                                                    }
-                                                                                                                                                    Failed => Failed,
-                                                                                                                                                }
-                                                                                                                                            }
-                                                                                                                                            Failed => Failed,
-                                                                                                                                        }
-                                                                                                                                    };
-                                                                                                                                    match __seq_res {
-                                                                                                                                        Matched(__pos, e) => Matched(__pos, { TypeSpecifier::Enum(e) }),
-                                                                                                                                        Failed => Failed,
-                                                                                                                                    }
-                                                                                                                                };
-                                                                                                                                match __choice_res {
-                                                                                                                                    Matched(__pos, __value) => Matched(__pos, __value),
-                                                                                                                                    Failed => {
-                                                                                                                                        let __seq_res = {
-                                                                                                                                            __state.suppress_fail += 1;
-                                                                                                                                            let __assert_res = __parse_gnu_guard(__input, __state, __pos, env);
-                                                                                                                                            __state.suppress_fail -= 1;
-                                                                                                                                            match __assert_res {
-                                                                                                                                                Matched(_, __value) => Matched(__pos, __value),
-                                                                                                                                                Failed => Failed,
-                                                                                                                                            }
-                                                                                                                                        };
-                                                                                                                                        match __seq_res {
-                                                                                                                                            Matched(__pos, _) => {
-                                                                                                                                                let __seq_res = __parse_typeof_specifier(__input, __state, __pos, env);
-                                                                                                                                                match __seq_res {
-                                                                                                                                                    Matched(__pos, e) => Matched(__pos, { e }),
-                                                                                                                                                    Failed => Failed,
-                                                                                                                                                }
-                                                                                                                                            }
-                                                                                                                                            Failed => Failed,
-                                                                                                                                        }
-                                                                                                                                    }
-                                                                                                                                }
-                                                                                                                            }
-                                                                                                                        }
-                                                                                                                    }
-                                                                                                                }
-                                                                                                            }
-                                                                                                        }
-                                                                                                    }
+                                                                                        match __seq_res {
+                                                                                            Matched(__pos, _) => {
+                                                                                                let __seq_res = __parse_typeof_specifier(__input, __state, __pos, env);
+                                                                                                match __seq_res {
+                                                                                                    Matched(__pos, e) => Matched(__pos, { e }),
+                                                                                                    Failed => Failed,
                                                                                                 }
                                                                                             }
+                                                                                            Failed => Failed,
                                                                                         }
                                                                                     }
                                                                                 }
@@ -6917,43 +7221,7 @@ fn __parse_struct_declaration<'input>(__input: &'input str, __state: &mut ParseS
 fn __parse_struct_field<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<StructField> {
     #![allow(non_snake_case, unused)]
     {
-        let __seq_res = {
-            let __seq_res = {
-                let mut __repeat_pos = __pos;
-                let mut __repeat_value = vec![];
-                loop {
-                    let __pos = __repeat_pos;
-                    let __pos = if __repeat_value.len() > 0 {
-                        let __sep_res = __parse__(__input, __state, __pos, env);
-                        match __sep_res {
-                            Matched(__newpos, _) => __newpos,
-                            Failed => break,
-                        }
-                    } else {
-                        __pos
-                    };
-                    let __step_res = __parse_specifier_qualifier(__input, __state, __pos, env);
-                    match __step_res {
-                        Matched(__newpos, __value) => {
-                            __repeat_pos = __newpos;
-                            __repeat_value.push(__value);
-                        }
-                        Failed => {
-                            break;
-                        }
-                    }
-                }
-                if __repeat_value.len() >= 1 {
-                    Matched(__repeat_pos, __repeat_value)
-                } else {
-                    Failed
-                }
-            };
-            match __seq_res {
-                Matched(__pos, e) => Matched(__pos, { e }),
-                Failed => Failed,
-            }
-        };
+        let __seq_res = __parse_specifier_qualifiers(__input, __state, __pos, env);
         match __seq_res {
             Matched(__pos, s) => {
                 let __seq_res = __parse__(__input, __state, __pos, env);
@@ -7047,48 +7315,412 @@ fn __parse_struct_field<'input>(__input: &'input str, __state: &mut ParseState<'
     }
 }
 
-fn __parse_specifier_qualifier<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Node<SpecifierQualifier>> {
-    #![allow(non_snake_case, unused)]
-    {
-        let __seq_res = Matched(__pos, __pos);
-        match __seq_res {
-            Matched(__pos, l) => {
-                let __seq_res = __parse_specifier_qualifier0(__input, __state, __pos, env);
-                match __seq_res {
-                    Matched(__pos, e) => {
-                        let __seq_res = Matched(__pos, __pos);
-                        match __seq_res {
-                            Matched(__pos, r) => Matched(__pos, { Node::new(e, Span::span(l, r)) }),
-                            Failed => Failed,
-                        }
-                    }
-                    Failed => Failed,
-                }
-            }
-            Failed => Failed,
-        }
-    }
-}
-
-fn __parse_specifier_qualifier0<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<SpecifierQualifier> {
+fn __parse_specifier_qualifiers<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Vec<Node<SpecifierQualifier>>> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
-            let __seq_res = __parse_type_specifier(__input, __state, __pos, env);
+            let __seq_res = {
+                let __seq_res = {
+                    let mut __repeat_pos = __pos;
+                    let mut __repeat_value = vec![];
+                    loop {
+                        let __pos = __repeat_pos;
+                        let __pos = if __repeat_value.len() > 0 {
+                            let __sep_res = __parse__(__input, __state, __pos, env);
+                            match __sep_res {
+                                Matched(__newpos, _) => __newpos,
+                                Failed => break,
+                            }
+                        } else {
+                            __pos
+                        };
+                        let __step_res = {
+                            let __seq_res = Matched(__pos, __pos);
+                            match __seq_res {
+                                Matched(__pos, l) => {
+                                    let __seq_res = __parse_specifier_qualifier_qualifier0(__input, __state, __pos, env);
+                                    match __seq_res {
+                                        Matched(__pos, e) => {
+                                            let __seq_res = Matched(__pos, __pos);
+                                            match __seq_res {
+                                                Matched(__pos, r) => Matched(__pos, { Node::new(e, Span::span(l, r)) }),
+                                                Failed => Failed,
+                                            }
+                                        }
+                                        Failed => Failed,
+                                    }
+                                }
+                                Failed => Failed,
+                            }
+                        };
+                        match __step_res {
+                            Matched(__newpos, __value) => {
+                                __repeat_pos = __newpos;
+                                __repeat_value.push(__value);
+                            }
+                            Failed => {
+                                break;
+                            }
+                        }
+                    }
+                    Matched(__repeat_pos, __repeat_value)
+                };
+                match __seq_res {
+                    Matched(__pos, e) => Matched(__pos, { e }),
+                    Failed => Failed,
+                }
+            };
             match __seq_res {
-                Matched(__pos, s) => Matched(__pos, { SpecifierQualifier::TypeSpecifier(s) }),
+                Matched(__pos, before) => {
+                    let __seq_res = __parse__(__input, __state, __pos, env);
+                    match __seq_res {
+                        Matched(__pos, _) => {
+                            let __seq_res = {
+                                let __seq_res = Matched(__pos, __pos);
+                                match __seq_res {
+                                    Matched(__pos, l) => {
+                                        let __seq_res = __parse_specifier_qualifier_unique_type0(__input, __state, __pos, env);
+                                        match __seq_res {
+                                            Matched(__pos, e) => {
+                                                let __seq_res = Matched(__pos, __pos);
+                                                match __seq_res {
+                                                    Matched(__pos, r) => Matched(__pos, { Node::new(e, Span::span(l, r)) }),
+                                                    Failed => Failed,
+                                                }
+                                            }
+                                            Failed => Failed,
+                                        }
+                                    }
+                                    Failed => Failed,
+                                }
+                            };
+                            match __seq_res {
+                                Matched(__pos, single) => {
+                                    let __seq_res = __parse__(__input, __state, __pos, env);
+                                    match __seq_res {
+                                        Matched(__pos, _) => {
+                                            let __seq_res = {
+                                                let __seq_res = {
+                                                    let mut __repeat_pos = __pos;
+                                                    let mut __repeat_value = vec![];
+                                                    loop {
+                                                        let __pos = __repeat_pos;
+                                                        let __pos = if __repeat_value.len() > 0 {
+                                                            let __sep_res = __parse__(__input, __state, __pos, env);
+                                                            match __sep_res {
+                                                                Matched(__newpos, _) => __newpos,
+                                                                Failed => break,
+                                                            }
+                                                        } else {
+                                                            __pos
+                                                        };
+                                                        let __step_res = {
+                                                            let __seq_res = Matched(__pos, __pos);
+                                                            match __seq_res {
+                                                                Matched(__pos, l) => {
+                                                                    let __seq_res = __parse_specifier_qualifier_qualifier0(__input, __state, __pos, env);
+                                                                    match __seq_res {
+                                                                        Matched(__pos, e) => {
+                                                                            let __seq_res = Matched(__pos, __pos);
+                                                                            match __seq_res {
+                                                                                Matched(__pos, r) => Matched(__pos, { Node::new(e, Span::span(l, r)) }),
+                                                                                Failed => Failed,
+                                                                            }
+                                                                        }
+                                                                        Failed => Failed,
+                                                                    }
+                                                                }
+                                                                Failed => Failed,
+                                                            }
+                                                        };
+                                                        match __step_res {
+                                                            Matched(__newpos, __value) => {
+                                                                __repeat_pos = __newpos;
+                                                                __repeat_value.push(__value);
+                                                            }
+                                                            Failed => {
+                                                                break;
+                                                            }
+                                                        }
+                                                    }
+                                                    Matched(__repeat_pos, __repeat_value)
+                                                };
+                                                match __seq_res {
+                                                    Matched(__pos, e) => Matched(__pos, { e }),
+                                                    Failed => Failed,
+                                                }
+                                            };
+                                            match __seq_res {
+                                                Matched(__pos, after) => Matched(__pos, {
+                                                    let mut before = before;
+                                                    before.push(single);
+                                                    before.extend(after);
+                                                    before
+                                                }),
+                                                Failed => Failed,
+                                            }
+                                        }
+                                        Failed => Failed,
+                                    }
+                                }
+                                Failed => Failed,
+                            }
+                        }
+                        Failed => Failed,
+                    }
+                }
                 Failed => Failed,
             }
         };
         match __choice_res {
             Matched(__pos, __value) => Matched(__pos, __value),
             Failed => {
-                let __seq_res = __parse_type_qualifier(__input, __state, __pos, env);
+                let __seq_res = {
+                    let __seq_res = {
+                        let mut __repeat_pos = __pos;
+                        let mut __repeat_value = vec![];
+                        loop {
+                            let __pos = __repeat_pos;
+                            let __pos = if __repeat_value.len() > 0 {
+                                let __sep_res = __parse__(__input, __state, __pos, env);
+                                match __sep_res {
+                                    Matched(__newpos, _) => __newpos,
+                                    Failed => break,
+                                }
+                            } else {
+                                __pos
+                            };
+                            let __step_res = {
+                                let __seq_res = Matched(__pos, __pos);
+                                match __seq_res {
+                                    Matched(__pos, l) => {
+                                        let __seq_res = __parse_specifier_qualifier_qualifier0(__input, __state, __pos, env);
+                                        match __seq_res {
+                                            Matched(__pos, e) => {
+                                                let __seq_res = Matched(__pos, __pos);
+                                                match __seq_res {
+                                                    Matched(__pos, r) => Matched(__pos, { Node::new(e, Span::span(l, r)) }),
+                                                    Failed => Failed,
+                                                }
+                                            }
+                                            Failed => Failed,
+                                        }
+                                    }
+                                    Failed => Failed,
+                                }
+                            };
+                            match __step_res {
+                                Matched(__newpos, __value) => {
+                                    __repeat_pos = __newpos;
+                                    __repeat_value.push(__value);
+                                }
+                                Failed => {
+                                    break;
+                                }
+                            }
+                        }
+                        Matched(__repeat_pos, __repeat_value)
+                    };
+                    match __seq_res {
+                        Matched(__pos, e) => Matched(__pos, { e }),
+                        Failed => Failed,
+                    }
+                };
                 match __seq_res {
-                    Matched(__pos, q) => Matched(__pos, { SpecifierQualifier::TypeQualifier(q) }),
+                    Matched(__pos, before) => {
+                        let __seq_res = __parse__(__input, __state, __pos, env);
+                        match __seq_res {
+                            Matched(__pos, _) => {
+                                let __seq_res = {
+                                    let __seq_res = Matched(__pos, __pos);
+                                    match __seq_res {
+                                        Matched(__pos, l) => {
+                                            let __seq_res = __parse_specifier_qualifier_nonunique_type0(__input, __state, __pos, env);
+                                            match __seq_res {
+                                                Matched(__pos, e) => {
+                                                    let __seq_res = Matched(__pos, __pos);
+                                                    match __seq_res {
+                                                        Matched(__pos, r) => Matched(__pos, { Node::new(e, Span::span(l, r)) }),
+                                                        Failed => Failed,
+                                                    }
+                                                }
+                                                Failed => Failed,
+                                            }
+                                        }
+                                        Failed => Failed,
+                                    }
+                                };
+                                match __seq_res {
+                                    Matched(__pos, single) => {
+                                        let __seq_res = __parse__(__input, __state, __pos, env);
+                                        match __seq_res {
+                                            Matched(__pos, _) => {
+                                                let __seq_res = {
+                                                    let __seq_res = {
+                                                        let mut __repeat_pos = __pos;
+                                                        let mut __repeat_value = vec![];
+                                                        loop {
+                                                            let __pos = __repeat_pos;
+                                                            let __pos = if __repeat_value.len() > 0 {
+                                                                let __sep_res = __parse__(__input, __state, __pos, env);
+                                                                match __sep_res {
+                                                                    Matched(__newpos, _) => __newpos,
+                                                                    Failed => break,
+                                                                }
+                                                            } else {
+                                                                __pos
+                                                            };
+                                                            let __step_res = {
+                                                                let __choice_res = {
+                                                                    let __seq_res = Matched(__pos, __pos);
+                                                                    match __seq_res {
+                                                                        Matched(__pos, l) => {
+                                                                            let __seq_res = __parse_specifier_qualifier_nonunique_type0(__input, __state, __pos, env);
+                                                                            match __seq_res {
+                                                                                Matched(__pos, e) => {
+                                                                                    let __seq_res = Matched(__pos, __pos);
+                                                                                    match __seq_res {
+                                                                                        Matched(__pos, r) => Matched(__pos, { Node::new(e, Span::span(l, r)) }),
+                                                                                        Failed => Failed,
+                                                                                    }
+                                                                                }
+                                                                                Failed => Failed,
+                                                                            }
+                                                                        }
+                                                                        Failed => Failed,
+                                                                    }
+                                                                };
+                                                                match __choice_res {
+                                                                    Matched(__pos, __value) => Matched(__pos, __value),
+                                                                    Failed => {
+                                                                        let __seq_res = Matched(__pos, __pos);
+                                                                        match __seq_res {
+                                                                            Matched(__pos, l) => {
+                                                                                let __seq_res = __parse_specifier_qualifier_qualifier0(__input, __state, __pos, env);
+                                                                                match __seq_res {
+                                                                                    Matched(__pos, e) => {
+                                                                                        let __seq_res = Matched(__pos, __pos);
+                                                                                        match __seq_res {
+                                                                                            Matched(__pos, r) => Matched(__pos, { Node::new(e, Span::span(l, r)) }),
+                                                                                            Failed => Failed,
+                                                                                        }
+                                                                                    }
+                                                                                    Failed => Failed,
+                                                                                }
+                                                                            }
+                                                                            Failed => Failed,
+                                                                        }
+                                                                    }
+                                                                }
+                                                            };
+                                                            match __step_res {
+                                                                Matched(__newpos, __value) => {
+                                                                    __repeat_pos = __newpos;
+                                                                    __repeat_value.push(__value);
+                                                                }
+                                                                Failed => {
+                                                                    break;
+                                                                }
+                                                            }
+                                                        }
+                                                        Matched(__repeat_pos, __repeat_value)
+                                                    };
+                                                    match __seq_res {
+                                                        Matched(__pos, e) => Matched(__pos, { e }),
+                                                        Failed => Failed,
+                                                    }
+                                                };
+                                                match __seq_res {
+                                                    Matched(__pos, after) => Matched(__pos, {
+                                                        let mut before = before;
+                                                        before.push(single);
+                                                        before.extend(after);
+                                                        before
+                                                    }),
+                                                    Failed => Failed,
+                                                }
+                                            }
+                                            Failed => Failed,
+                                        }
+                                    }
+                                    Failed => Failed,
+                                }
+                            }
+                            Failed => Failed,
+                        }
+                    }
                     Failed => Failed,
                 }
             }
+        }
+    }
+}
+
+fn __parse_specifier_qualifier_unique_type0<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<SpecifierQualifier> {
+    #![allow(non_snake_case, unused)]
+    {
+        let __seq_res = {
+            let __seq_res = Matched(__pos, __pos);
+            match __seq_res {
+                Matched(__pos, l) => {
+                    let __seq_res = __parse_type_specifier_unique(__input, __state, __pos, env);
+                    match __seq_res {
+                        Matched(__pos, e) => {
+                            let __seq_res = Matched(__pos, __pos);
+                            match __seq_res {
+                                Matched(__pos, r) => Matched(__pos, { Node::new(e, Span::span(l, r)) }),
+                                Failed => Failed,
+                            }
+                        }
+                        Failed => Failed,
+                    }
+                }
+                Failed => Failed,
+            }
+        };
+        match __seq_res {
+            Matched(__pos, s) => Matched(__pos, { SpecifierQualifier::TypeSpecifier(s) }),
+            Failed => Failed,
+        }
+    }
+}
+
+fn __parse_specifier_qualifier_nonunique_type0<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<SpecifierQualifier> {
+    #![allow(non_snake_case, unused)]
+    {
+        let __seq_res = {
+            let __seq_res = Matched(__pos, __pos);
+            match __seq_res {
+                Matched(__pos, l) => {
+                    let __seq_res = __parse_type_specifier_nonunique(__input, __state, __pos, env);
+                    match __seq_res {
+                        Matched(__pos, e) => {
+                            let __seq_res = Matched(__pos, __pos);
+                            match __seq_res {
+                                Matched(__pos, r) => Matched(__pos, { Node::new(e, Span::span(l, r)) }),
+                                Failed => Failed,
+                            }
+                        }
+                        Failed => Failed,
+                    }
+                }
+                Failed => Failed,
+            }
+        };
+        match __seq_res {
+            Matched(__pos, s) => Matched(__pos, { SpecifierQualifier::TypeSpecifier(s) }),
+            Failed => Failed,
+        }
+    }
+}
+
+fn __parse_specifier_qualifier_qualifier0<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<SpecifierQualifier> {
+    #![allow(non_snake_case, unused)]
+    {
+        let __seq_res = __parse_type_qualifier(__input, __state, __pos, env);
+        match __seq_res {
+            Matched(__pos, q) => Matched(__pos, { SpecifierQualifier::TypeQualifier(q) }),
+            Failed => Failed,
         }
     }
 }
@@ -7958,7 +8590,27 @@ fn __parse_type_qualifier0<'input>(__input: &'input str, __state: &mut ParseStat
                                                             res
                                                         };
                                                         match __seq_res {
-                                                            Matched(__pos, _) => Matched(__pos, { TypeQualifier::Atomic }),
+                                                            Matched(__pos, _) => {
+                                                                let __seq_res = __parse__(__input, __state, __pos, env);
+                                                                match __seq_res {
+                                                                    Matched(__pos, _) => {
+                                                                        let __seq_res = {
+                                                                            __state.suppress_fail += 1;
+                                                                            let __assert_res = slice_eq(__input, __state, __pos, "(");
+                                                                            __state.suppress_fail -= 1;
+                                                                            match __assert_res {
+                                                                                Failed => Matched(__pos, ()),
+                                                                                Matched(..) => Failed,
+                                                                            }
+                                                                        };
+                                                                        match __seq_res {
+                                                                            Matched(__pos, _) => Matched(__pos, { TypeQualifier::Atomic }),
+                                                                            Failed => Failed,
+                                                                        }
+                                                                    }
+                                                                    Failed => Failed,
+                                                                }
+                                                            }
                                                             Failed => Failed,
                                                         }
                                                     }
@@ -8592,16 +9244,44 @@ fn __parse_derived_declarator<'input>(__input: &'input str, __state: &mut ParseS
                             match __seq_res {
                                 Matched(__pos, _) => {
                                     let __seq_res = {
-                                        let __seq_res = Matched(__pos, __pos);
+                                        let __seq_res = Matched(__pos, {
+                                            env.enter_scope();
+                                        });
                                         match __seq_res {
-                                            Matched(__pos, l) => {
-                                                let __seq_res = __parse_function_declarator(__input, __state, __pos, env);
+                                            Matched(__pos, _) => {
+                                                let __seq_res = match {
+                                                    let __seq_res = Matched(__pos, __pos);
+                                                    match __seq_res {
+                                                        Matched(__pos, l) => {
+                                                            let __seq_res = __parse_function_declarator(__input, __state, __pos, env);
+                                                            match __seq_res {
+                                                                Matched(__pos, e) => {
+                                                                    let __seq_res = Matched(__pos, __pos);
+                                                                    match __seq_res {
+                                                                        Matched(__pos, r) => Matched(__pos, { Node::new(e, Span::span(l, r)) }),
+                                                                        Failed => Failed,
+                                                                    }
+                                                                }
+                                                                Failed => Failed,
+                                                            }
+                                                        }
+                                                        Failed => Failed,
+                                                    }
+                                                } {
+                                                    Matched(__newpos, __value) => Matched(__newpos, Some(__value)),
+                                                    Failed => Matched(__pos, None),
+                                                };
                                                 match __seq_res {
                                                     Matched(__pos, e) => {
-                                                        let __seq_res = Matched(__pos, __pos);
-                                                        match __seq_res {
-                                                            Matched(__pos, r) => Matched(__pos, { Node::new(e, Span::span(l, r)) }),
-                                                            Failed => Failed,
+                                                        match {
+                                                            env.leave_scope();
+                                                            e.ok_or("")
+                                                        } {
+                                                            Ok(res) => Matched(__pos, res),
+                                                            Err(expected) => {
+                                                                __state.mark_failure(__pos, expected);
+                                                                Failed
+                                                            }
                                                         }
                                                     }
                                                     Failed => Failed,
@@ -9402,43 +10082,7 @@ fn __parse_parameter_declaration<'input>(__input: &'input str, __state: &mut Par
 fn __parse_parameter_declaration0<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<ParameterDeclaration> {
     #![allow(non_snake_case, unused)]
     {
-        let __seq_res = {
-            let __seq_res = {
-                let mut __repeat_pos = __pos;
-                let mut __repeat_value = vec![];
-                loop {
-                    let __pos = __repeat_pos;
-                    let __pos = if __repeat_value.len() > 0 {
-                        let __sep_res = __parse__(__input, __state, __pos, env);
-                        match __sep_res {
-                            Matched(__newpos, _) => __newpos,
-                            Failed => break,
-                        }
-                    } else {
-                        __pos
-                    };
-                    let __step_res = __parse_declaration_specifier(__input, __state, __pos, env);
-                    match __step_res {
-                        Matched(__newpos, __value) => {
-                            __repeat_pos = __newpos;
-                            __repeat_value.push(__value);
-                        }
-                        Failed => {
-                            break;
-                        }
-                    }
-                }
-                if __repeat_value.len() >= 1 {
-                    Matched(__repeat_pos, __repeat_value)
-                } else {
-                    Failed
-                }
-            };
-            match __seq_res {
-                Matched(__pos, e) => Matched(__pos, { e }),
-                Failed => Failed,
-            }
-        };
+        let __seq_res = __parse_declaration_specifiers(__input, __state, __pos, env);
         match __seq_res {
             Matched(__pos, s) => {
                 let __seq_res = __parse__(__input, __state, __pos, env);
@@ -9475,7 +10119,10 @@ fn __parse_parameter_declaration0<'input>(__input: &'input str, __state: &mut Pa
                                             Failed => Matched(__pos, None),
                                         };
                                         match __seq_res {
-                                            Matched(__pos, a) => Matched(__pos, { ParameterDeclaration { specifiers: s, declarator: d, extensions: a.unwrap_or_default() } }),
+                                            Matched(__pos, a) => Matched(__pos, {
+                                                env.handle_declaration(&s, d.iter());
+                                                ParameterDeclaration { specifiers: s, declarator: d, extensions: a.unwrap_or_default() }
+                                            }),
                                             Failed => Failed,
                                         }
                                     }
@@ -9548,43 +10195,7 @@ fn __parse_type_name<'input>(__input: &'input str, __state: &mut ParseState<'inp
 fn __parse_type_name0<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<TypeName> {
     #![allow(non_snake_case, unused)]
     {
-        let __seq_res = {
-            let __seq_res = {
-                let mut __repeat_pos = __pos;
-                let mut __repeat_value = vec![];
-                loop {
-                    let __pos = __repeat_pos;
-                    let __pos = if __repeat_value.len() > 0 {
-                        let __sep_res = __parse__(__input, __state, __pos, env);
-                        match __sep_res {
-                            Matched(__newpos, _) => __newpos,
-                            Failed => break,
-                        }
-                    } else {
-                        __pos
-                    };
-                    let __step_res = __parse_specifier_qualifier(__input, __state, __pos, env);
-                    match __step_res {
-                        Matched(__newpos, __value) => {
-                            __repeat_pos = __newpos;
-                            __repeat_value.push(__value);
-                        }
-                        Failed => {
-                            break;
-                        }
-                    }
-                }
-                if __repeat_value.len() >= 1 {
-                    Matched(__repeat_pos, __repeat_value)
-                } else {
-                    Failed
-                }
-            };
-            match __seq_res {
-                Matched(__pos, e) => Matched(__pos, { e }),
-                Failed => Failed,
-            }
-        };
+        let __seq_res = __parse_specifier_qualifiers(__input, __state, __pos, env);
         match __seq_res {
             Matched(__pos, s) => {
                 let __seq_res = __parse__(__input, __state, __pos, env);
@@ -11399,7 +12010,35 @@ fn __parse_statement0<'input>(__input: &'input str, __state: &mut ParseState<'in
         match __choice_res {
             Matched(__pos, __value) => Matched(__pos, __value),
             Failed => {
-                let __choice_res = __parse_compound_statement(__input, __state, __pos, env);
+                let __choice_res = {
+                    let __seq_res = Matched(__pos, {
+                        env.enter_scope();
+                    });
+                    match __seq_res {
+                        Matched(__pos, _) => {
+                            let __seq_res = match __parse_compound_statement(__input, __state, __pos, env) {
+                                Matched(__newpos, __value) => Matched(__newpos, Some(__value)),
+                                Failed => Matched(__pos, None),
+                            };
+                            match __seq_res {
+                                Matched(__pos, e) => {
+                                    match {
+                                        env.leave_scope();
+                                        e.ok_or("")
+                                    } {
+                                        Ok(res) => Matched(__pos, res),
+                                        Err(expected) => {
+                                            __state.mark_failure(__pos, expected);
+                                            Failed
+                                        }
+                                    }
+                                }
+                                Failed => Failed,
+                            }
+                        }
+                        Failed => Failed,
+                    }
+                };
                 match __choice_res {
                     Matched(__pos, __value) => Matched(__pos, __value),
                     Failed => {
@@ -11411,7 +12050,35 @@ fn __parse_statement0<'input>(__input: &'input str, __state: &mut ParseState<'in
                                 match __choice_res {
                                     Matched(__pos, __value) => Matched(__pos, __value),
                                     Failed => {
-                                        let __choice_res = __parse_iteration_statement(__input, __state, __pos, env);
+                                        let __choice_res = {
+                                            let __seq_res = Matched(__pos, {
+                                                env.enter_scope();
+                                            });
+                                            match __seq_res {
+                                                Matched(__pos, _) => {
+                                                    let __seq_res = match __parse_iteration_statement(__input, __state, __pos, env) {
+                                                        Matched(__newpos, __value) => Matched(__newpos, Some(__value)),
+                                                        Failed => Matched(__pos, None),
+                                                    };
+                                                    match __seq_res {
+                                                        Matched(__pos, e) => {
+                                                            match {
+                                                                env.leave_scope();
+                                                                e.ok_or("")
+                                                            } {
+                                                                Ok(res) => Matched(__pos, res),
+                                                                Err(expected) => {
+                                                                    __state.mark_failure(__pos, expected);
+                                                                    Failed
+                                                                }
+                                                            }
+                                                        }
+                                                        Failed => Failed,
+                                                    }
+                                                }
+                                                Failed => Failed,
+                                            }
+                                        };
                                         match __choice_res {
                                             Matched(__pos, __value) => Matched(__pos, __value),
                                             Failed => {
@@ -13120,43 +13787,7 @@ fn __parse_function_definition<'input>(__input: &'input str, __state: &mut Parse
                 let __seq_res = __parse__(__input, __state, __pos, env);
                 match __seq_res {
                     Matched(__pos, _) => {
-                        let __seq_res = {
-                            let __seq_res = {
-                                let mut __repeat_pos = __pos;
-                                let mut __repeat_value = vec![];
-                                loop {
-                                    let __pos = __repeat_pos;
-                                    let __pos = if __repeat_value.len() > 0 {
-                                        let __sep_res = __parse__(__input, __state, __pos, env);
-                                        match __sep_res {
-                                            Matched(__newpos, _) => __newpos,
-                                            Failed => break,
-                                        }
-                                    } else {
-                                        __pos
-                                    };
-                                    let __step_res = __parse_declaration_specifier(__input, __state, __pos, env);
-                                    match __step_res {
-                                        Matched(__newpos, __value) => {
-                                            __repeat_pos = __newpos;
-                                            __repeat_value.push(__value);
-                                        }
-                                        Failed => {
-                                            break;
-                                        }
-                                    }
-                                }
-                                if __repeat_value.len() >= 1 {
-                                    Matched(__repeat_pos, __repeat_value)
-                                } else {
-                                    Failed
-                                }
-                            };
-                            match __seq_res {
-                                Matched(__pos, e) => Matched(__pos, { e }),
-                                Failed => Failed,
-                            }
-                        };
+                        let __seq_res = __parse_declaration_specifiers(__input, __state, __pos, env);
                         match __seq_res {
                             Matched(__pos, a) => {
                                 let __seq_res = __parse__(__input, __state, __pos, env);


### PR DESCRIPTION
Hey,

Thanks for this awesome project. I'm using it in my toy compiler and really like it.

However, I ran into a few issues with ambiguous declarations - the main blockers being cases that incorrectly failed to parse. I'm not too familiar with PEG-based parsers, so please let me know if anything in this commit can be implemented more efficiently. I used the great [A simple, possibly correct LR parser for C11](http://gallium.inria.fr/~fpottier/publis/jourdan-fpottier-2016.pdf) paper as reference.

 Here is a summary of all the ambiguous cases that this commit fixes:

```c
typedef int a;
void foo() {
  // This should create a variable "a". Previously was empty declarator of type "int a".
  int a;
  // a b;  // This should fail to parse, since "a" is no longer a typename.
}
```

```c
typedef int a;
// Should fail to compile, since "a*b" is not a declarator. Previously succeeded.
void foo(int a* b) {} 
```

```c
typedef int a;
struct a { a a, b };  // Should fail to compile. Previously succeeded
```

```c
typedef int a;
void foo(int a, _Atomic (a) b) {}  // Should fail to compile. Previously succeeded.
```

To do this changes, I had to modify Env to also record symbols as they're being declared, so that symbols can shadow typenames in upper scopes. I didn't bother to handle symbol redefinition since that is already a semantic error. 

I also added a whole bunch of test cases. I used a poor man's proof by counterexample for most cases, since comparing parse trees was a bit too cumbersome :). 

I still haven't fixed the ambiguity resulting from enum constants. E.g.:

```c
typedef int a;
int foo() {
  int x = (enum {a})1;
  // "a" is no longer a typename.
  _Atomic(a) b;   // Should fail to compile. Currently succeeds.
}
```