### PR TITLE
Fix parsing of const following typedef

### DIFF
--- a/grammar.rustpeg
+++ b/grammar.rustpeg
@@ -483,6 +483,9 @@ declaration_tail1<s> =
 
 // What can follow a typedef keyword
 declaration_typedef_tail -> (Vec<Node<DeclarationSpecifier>>, Vec<Node<InitDeclarator>>) =
+    declaration_seq<declaration_specifiers_unique, declaration_typedef_tail0>
+
+declaration_typedef_tail0 -> (Vec<Node<DeclarationSpecifier>>, Vec<Node<InitDeclarator>>) =
     declaration_seq<declaration_unique_type, declaration_typedef_tail1<declaration_specifiers_unique>> /
     declaration_seq<declaration_nonunique_type, declaration_typedef_tail1<declaration_specifiers_nonunique>>
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -5343,6 +5343,29 @@ fn __parse_declaration2<'input>(__input: &'input str, __state: &mut ParseState<'
 fn __parse_declaration_typedef_tail<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<(Vec<Node<DeclarationSpecifier>>, Vec<Node<InitDeclarator>>)> {
     #![allow(non_snake_case, unused)]
     {
+        let __seq_res = __parse_declaration_specifiers_unique(__input, __state, __pos, env);
+        match __seq_res {
+            Matched(__pos, h) => {
+                let __seq_res = __parse__(__input, __state, __pos, env);
+                match __seq_res {
+                    Matched(__pos, _) => {
+                        let __seq_res = __parse_declaration_typedef_tail0(__input, __state, __pos, env);
+                        match __seq_res {
+                            Matched(__pos, t) => Matched(__pos, { (concat(h, t.0), t.1) }),
+                            Failed => Failed,
+                        }
+                    }
+                    Failed => Failed,
+                }
+            }
+            Failed => Failed,
+        }
+    }
+}
+
+fn __parse_declaration_typedef_tail0<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<(Vec<Node<DeclarationSpecifier>>, Vec<Node<InitDeclarator>>)> {
+    #![allow(non_snake_case, unused)]
+    {
         let __choice_res = {
             let __seq_res = __parse_declaration_unique_type(__input, __state, __pos, env);
             match __seq_res {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2458,3 +2458,35 @@ fn test_compound_literal() {
         .into())
     );
 }
+
+// #23
+#[test]
+fn test_typedef_const() {
+    use ast::Declaration;
+    use ast::Declarator;
+    use ast::InitDeclarator;
+    use ast::StorageClassSpecifier::Typedef;
+    use ast::TypeQualifier::Const;
+    use ast::TypeSpecifier::Int;
+    use parser::declaration;
+
+    let env = &mut Env::with_core();
+
+    assert_eq!(
+        declaration("typedef const int foo;", env).unwrap(),
+        Declaration {
+            specifiers: vec![Typedef.into(), Const.into(), Int.into()],
+            declarators: vec![InitDeclarator {
+                declarator: Declarator {
+                    kind: ident("foo"),
+                    derived: vec![],
+                    extensions: vec![],
+                }
+                .into(),
+                initializer: None,
+            }
+            .into()],
+        }
+        .into()
+    );
+}


### PR DESCRIPTION
There is still possibility that a non-type keyword, such as type qualifier,
may be following `typedef` before we can parse the first type specifier.

Fixes #23