### PR TITLE
Added missing space between struct declarator and attribute

### DIFF
--- a/grammar.rustpeg
+++ b/grammar.rustpeg
@@ -666,7 +666,7 @@ struct_declarator -> StructDeclarator =
             bit_width: Some(e),
         }
     } /
-    d:declarator a:gnu<attribute_specifier_list>? {
+    d:declarator _ a:gnu<attribute_specifier_list>? {
         StructDeclarator {
             declarator: Some(with_ext(d, a)),
             bit_width: None,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -8293,32 +8293,38 @@ fn __parse_struct_declarator<'input>(__input: &'input str, __state: &mut ParseSt
                 let __seq_res = __parse_declarator(__input, __state, __pos, env);
                 match __seq_res {
                     Matched(__pos, d) => {
-                        let __seq_res = match {
-                            let __seq_res = {
-                                __state.suppress_fail += 1;
-                                let __assert_res = __parse_gnu_guard(__input, __state, __pos, env);
-                                __state.suppress_fail -= 1;
-                                match __assert_res {
-                                    Matched(_, __value) => Matched(__pos, __value),
-                                    Failed => Failed,
-                                }
-                            };
-                            match __seq_res {
-                                Matched(__pos, _) => {
-                                    let __seq_res = __parse_attribute_specifier_list(__input, __state, __pos, env);
+                        let __seq_res = __parse__(__input, __state, __pos, env);
+                        match __seq_res {
+                            Matched(__pos, _) => {
+                                let __seq_res = match {
+                                    let __seq_res = {
+                                        __state.suppress_fail += 1;
+                                        let __assert_res = __parse_gnu_guard(__input, __state, __pos, env);
+                                        __state.suppress_fail -= 1;
+                                        match __assert_res {
+                                            Matched(_, __value) => Matched(__pos, __value),
+                                            Failed => Failed,
+                                        }
+                                    };
                                     match __seq_res {
-                                        Matched(__pos, e) => Matched(__pos, { e }),
+                                        Matched(__pos, _) => {
+                                            let __seq_res = __parse_attribute_specifier_list(__input, __state, __pos, env);
+                                            match __seq_res {
+                                                Matched(__pos, e) => Matched(__pos, { e }),
+                                                Failed => Failed,
+                                            }
+                                        }
                                         Failed => Failed,
                                     }
+                                } {
+                                    Matched(__newpos, __value) => Matched(__newpos, Some(__value)),
+                                    Failed => Matched(__pos, None),
+                                };
+                                match __seq_res {
+                                    Matched(__pos, a) => Matched(__pos, { StructDeclarator { declarator: Some(with_ext(d, a)), bit_width: None } }),
+                                    Failed => Failed,
                                 }
-                                Failed => Failed,
                             }
-                        } {
-                            Matched(__newpos, __value) => Matched(__newpos, Some(__value)),
-                            Failed => Matched(__pos, None),
-                        };
-                        match __seq_res {
-                            Matched(__pos, a) => Matched(__pos, { StructDeclarator { declarator: Some(with_ext(d, a)), bit_width: None } }),
                             Failed => Failed,
                         }
                     }


### PR DESCRIPTION
This works:
```c
typdef struct
{
    int arr[2]__attribute__((aligned));
} mystruct;
```

This does not:
```c
typdef struct
{
    int arr[2] __attribute__((aligned));
} mystruct;
```

This PR fixes that.