### PR TITLE
Parse compound literals in expression context

### DIFF
--- a/grammar.rustpeg
+++ b/grammar.rustpeg
@@ -227,8 +227,8 @@ postfix_expression0 -> Expression =
     e:node<postfix_expression1> _ t:list0<node<postfix_expressionT>> { apply_ops(t, e).node }
 
 postfix_expression1 -> Expression =
-    primary_expression0 /
-    compound_literal
+    compound_literal /
+    primary_expression0
 
 postfix_expressionT -> Operation =
     index_operator /

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2341,10 +2341,10 @@ fn __parse_postfix_expression0<'input>(__input: &'input str, __state: &mut Parse
 fn __parse_postfix_expression1<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Expression> {
     #![allow(non_snake_case, unused)]
     {
-        let __choice_res = __parse_primary_expression0(__input, __state, __pos, env);
+        let __choice_res = __parse_compound_literal(__input, __state, __pos, env);
         match __choice_res {
             Matched(__pos, __value) => Matched(__pos, __value),
-            Failed => __parse_compound_literal(__input, __state, __pos, env),
+            Failed => __parse_primary_expression0(__input, __state, __pos, env),
         }
     }
 }


### PR DESCRIPTION
Parser mis-recognized typename part of a compound literal as a
parenthesized expression. This caused it to leave postfix_expression1
rule too early, and then fail trying to parse `{` as an operator.

Making parser try compound_literal first fixes the problem.

Fixes #27