### PR TITLE
Optionally switch Identifiers form std::String to a different type in order to support string interning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,15 @@ trace:
 	rm -f src/parser.rs
 	make peg=rust-peg-trace
 
-.INTERMEDIATE: src/parser.rs.raw src/parser.rs.fmt
+.INTERMEDIATE: src/parser.rs.raw src/parser.rs.pst src/parser.rs.fmt
 
-src/parser.rs.raw: grammar.rustpeg grammar.rustfmt grammar.header
+src/parser.rs.raw: grammar.rustpeg grammar.rustfmt grammar.header grammar.sed
 	$(peg) $< > $@
 
-src/parser.rs.fmt: src/parser.rs.raw
+src/parser.rs.pst: src/parser.rs.raw
+	sed -f grammar.sed $< > $@
+
+src/parser.rs.fmt: src/parser.rs.pst
 	rustfmt --config-path grammar.rustfmt < $< > $@
 
 src/parser.rs: src/parser.rs.fmt

--- a/grammar.rustpeg
+++ b/grammar.rustpeg
@@ -1,6 +1,8 @@
 // Written for peg 0.5.4
 
-#![arguments(env: &mut Env)]
+// Notice, that we use a generic type parameter T: ast::Name at various points in this grammar
+// The rust-peg output must be postprocessed to ensure, that a valid grammar is generated.
+#![arguments(env: &mut Env<T>)]
 
 use ast::*;
 use astutil::*;
@@ -53,13 +55,13 @@ K<E> = #quiet<e:E ![_a-zA-Z0-9] { e }>
 ////
 
 // Identifiers.
-identifier -> Node<Identifier> = node<identifier0>
+identifier -> Node<Identifier<T>> = node<identifier0>
 
-identifier0 -> Identifier =
+identifier0 -> Identifier<T> =
     n:$([_a-zA-Z] [_a-zA-Z0-9]*) {?
         if !env.reserved.contains(n) {
             Ok(Identifier {
-                name: n.into(),
+                name: T::get_from_str(n),
             })
         } else {
             Err("identifier")
@@ -188,9 +190,9 @@ string_char = [^"\\\n] / escape_sequence
 // 6.5.1 Primary expression
 ////
 
-primary_expression -> Box<Node<Expression>> = box<node<primary_expression0>>
+primary_expression -> Box<Node<Expression<T>>> = box<node<primary_expression0>>
 
-primary_expression0 -> Expression =
+primary_expression0 -> Expression<T> =
     a:identifier { Expression::Identifier(Box::new(a)) } /
     a:node<constant> { Expression::Constant(Box::new(a)) } /
     a:string_literal { Expression::StringLiteral(Box::new(a)) } /
@@ -198,7 +200,7 @@ primary_expression0 -> Expression =
     a:node<generic_selection> { Expression::GenericSelection(Box::new(a)) } /
     gnu<gnu_primary_expression>
 
-generic_selection -> GenericSelection =
+generic_selection -> GenericSelection<T> =
     K<"_Generic"> _ "(" _ e:assignment_expression _ "," _ a:cs1<node<generic_association>> _ ")" {
         GenericSelection {
             expression: e,
@@ -206,7 +208,7 @@ generic_selection -> GenericSelection =
         }
     }
 
-generic_association -> GenericAssociation =
+generic_association -> GenericAssociation<T> =
     t:type_name _ ":" _ e:assignment_expression {
         let span = Span::span(t.span.start, e.span.end);
         GenericAssociation::Type(Node::new(GenericAssociationType {
@@ -220,26 +222,26 @@ generic_association -> GenericAssociation =
 
 //// 6.5.2 Postfix operators
 
-postfix_expression -> Box<Node<Expression>> = box<node<postfix_expression0>>
+postfix_expression -> Box<Node<Expression<T>>> = box<node<postfix_expression0>>
 
 #[cache]
-postfix_expression0 -> Expression =
+postfix_expression0 -> Expression<T> =
     e:node<postfix_expression1> _ t:list0<node<postfix_expressionT>> { apply_ops(t, e).node }
 
-postfix_expression1 -> Expression =
+postfix_expression1 -> Expression<T> =
     compound_literal /
     primary_expression0
 
-postfix_expressionT -> Operation =
+postfix_expressionT -> Operation<T> =
     index_operator /
     "(" _ e:cs0<node<assignment_expression0>> _ ")" { Operation::Call(e) } /
     o:node<member_operator> _ i:identifier { Operation::Member(o, i) } /
     o:node<postfix_operator> { Operation::Unary(o) }
 
-index_operator -> Operation =
+index_operator -> Operation<T> =
     i:node<index_operator0> { Operation::Binary(Node::new(BinaryOperator::Index, i.span), i.node) }
 
-index_operator0 -> Node<Expression> =
+index_operator0 -> Node<Expression<T>> =
     "[" _ e:node<expression0> _ "]" { e }
 
 member_operator -> MemberOperator =
@@ -250,10 +252,10 @@ postfix_operator -> UnaryOperator =
     "++" { UnaryOperator::PostIncrement } /
     "--" { UnaryOperator::PostDecrement }
 
-compound_literal -> Expression =
+compound_literal -> Expression<T> =
     n:node<compound_literal_inner> { Expression::CompoundLiteral(Box::new(n)) }
 
-compound_literal_inner -> CompoundLiteral =
+compound_literal_inner -> CompoundLiteral<T> =
     "(" _ t:type_name _ ")" _ "{" _ i:cs1<node<initializer_list_item>> _ ","? _ "}" {
         CompoundLiteral {
             type_name: t,
@@ -265,9 +267,9 @@ compound_literal_inner -> CompoundLiteral =
 // 6.5.3 Unary operators
 ////
 
-unary_expression -> Box<Node<Expression>> = box<node<unary_expression0>>
+unary_expression -> Box<Node<Expression<T>>> = box<node<unary_expression0>>
 
-unary_expression0 -> Expression =
+unary_expression0 -> Expression<T> =
     postfix_expression0 /
     unary_prefix /
     unary_cast /
@@ -275,10 +277,10 @@ unary_expression0 -> Expression =
     alignof_expression /
     gnu<K<"__extension__">> _ e:unary_expression0 { e }
 
-unary_prefix -> Expression =
+unary_prefix -> Expression<T> =
     n:node<unary_prefix_inner> { Expression::UnaryOperator(Box::new(n)) }
 
-unary_prefix_inner -> UnaryOperatorExpression =
+unary_prefix_inner -> UnaryOperatorExpression<T> =
     op:node<prefix_operator> _ e:unary_expression {
         UnaryOperatorExpression {
             operator: op,
@@ -291,10 +293,10 @@ prefix_operator -> UnaryOperator =
     "--" { UnaryOperator::PreDecrement } /
     K<"sizeof"> { UnaryOperator::SizeOf }
 
-unary_cast -> Expression =
+unary_cast -> Expression<T> =
     n:node<unary_cast_inner> { Expression::UnaryOperator(Box::new(n)) }
 
-unary_cast_inner -> UnaryOperatorExpression =
+unary_cast_inner -> UnaryOperatorExpression<T> =
     op:node<unary_operator> _ e:cast_expression {
         UnaryOperatorExpression {
             operator: op,
@@ -310,12 +312,12 @@ unary_operator -> UnaryOperator =
     "~" { UnaryOperator::Complement } /
     "!" { UnaryOperator::Negate }
 
-sizeof_expression -> Expression =
+sizeof_expression -> Expression<T> =
     K<"sizeof"> _ "(" _ t:type_name _ ")" {
         Expression::SizeOf(Box::new(t))
     }
 
-alignof_expression -> Expression =
+alignof_expression -> Expression<T> =
     K<"_Alignof" / gnu<"__alignof" "__"?>> _ "(" _ t:type_name _ ")" {
         Expression::AlignOf(Box::new(t))
     }
@@ -324,13 +326,13 @@ alignof_expression -> Expression =
 // 6.5.4 Cast expressions
 ////
 
-cast_expression -> Box<Node<Expression>> = box<node<cast_expression0>>
+cast_expression -> Box<Node<Expression<T>>> = box<node<cast_expression0>>
 
-cast_expression0 -> Expression =
+cast_expression0 -> Expression<T> =
     c:node<cast_expression_inner> { Expression::Cast(Box::new(c)) } /
     unary_expression0
 
-cast_expression_inner -> CastExpression =
+cast_expression_inner -> CastExpression<T> =
     "(" _ t:type_name _ ")" _ e:cast_expression {
         CastExpression {
             type_name: t,
@@ -342,9 +344,9 @@ cast_expression_inner -> CastExpression =
 // 6.5.5 -- 6.5.14 Binary operators
 ////
 
-binary_expression -> Box<Node<Expression>> = box<binary_expression0>
+binary_expression -> Box<Node<Expression<T>>> = box<binary_expression0>
 
-binary_expression0 -> Node<Expression> = #infix<binary_operand> {
+binary_expression0 -> Node<Expression<T>> = #infix<binary_operand> {
 #L  x o:infix<"||"> y { infix(o, BinaryOperator::LogicalOr, x, y) }
 #L  x o:infix<"&&"> y { infix(o, BinaryOperator::LogicalAnd, x, y) }
 #L  x o:infix<"|"> y { infix(o, BinaryOperator::BitwiseOr, x, y) }
@@ -367,15 +369,15 @@ binary_expression0 -> Node<Expression> = #infix<binary_operand> {
 
 infix<ex> = _ n:node<ex> _ { n }
 
-binary_operand -> Node<Expression> = node<cast_expression0>
+binary_operand -> Node<Expression<T>> = node<cast_expression0>
 
 ////
 // 6.5.15 Conditional operator
 ////
 
-conditional_expression -> Box<Node<Expression>> = box<node<conditional_expression0>>
+conditional_expression -> Box<Node<Expression<T>>> = box<node<conditional_expression0>>
 
-conditional_expression0 -> Expression =
+conditional_expression0 -> Expression<T> =
     a:binary_expression0 _ t:conditional_expressionT? {
         if let Some((b, c)) = t {
             let span = Span::span(a.span.start, c.span.end);
@@ -389,20 +391,20 @@ conditional_expression0 -> Expression =
         }
     }
 
-conditional_expressionT -> (Box<Node<Expression>>, Box<Node<Expression>>) =
+conditional_expressionT -> (Box<Node<Expression<T>>>, Box<Node<Expression<T>>>) =
     "?" _ a:node<expression0> _ ":" _ b:node<conditional_expression0> { (Box::new(a), Box::new(b)) }
 
 ////
 // 6.5.16 Assignment operators
 ////
 
-assignment_expression -> Box<Node<Expression>> = box<node<assignment_expression0>>
+assignment_expression -> Box<Node<Expression<T>>> = box<node<assignment_expression0>>
 
-assignment_expression0 -> Expression =
+assignment_expression0 -> Expression<T> =
     n:node<assignment_expression_inner> { Expression::BinaryOperator(Box::new(n)) } /
     conditional_expression0
 
-assignment_expression_inner -> BinaryOperatorExpression =
+assignment_expression_inner -> BinaryOperatorExpression<T> =
     a:unary_expression _ op:node<assignment_operator> _ b:assignment_expression {
         BinaryOperatorExpression {
             operator: op,
@@ -428,9 +430,9 @@ assignment_operator -> BinaryOperator =
 // 6.5.17 Comma operator
 ////
 
-pub expression -> Box<Node<Expression>> = box<node<expression0>>
+pub expression -> Box<Node<Expression<T>>> = box<node<expression0>>
 
-expression0 -> Expression =
+expression0 -> Expression<T> =
     e:node<assignment_expression0> _ t:list0<expressionT> {
         if t.len() > 0 {
             let mut t  = t;
@@ -441,23 +443,23 @@ expression0 -> Expression =
         }
     }
 
-expressionT -> Node<Expression> =
+expressionT -> Node<Expression<T>> =
     "," _ e:node<assignment_expression0> { e }
 
 ////
 // 6.6 Constant expressions
 ////
 
-constant_expression -> Box<Node<Expression>> = conditional_expression
-constant_expression0 -> Expression = conditional_expression0
+constant_expression -> Box<Node<Expression<T>>> = conditional_expression
+constant_expression0 -> Expression<T> = conditional_expression0
 
 ////
 // 6.7 Declarations
 ////
 
-pub declaration -> Node<Declaration> = node<declaration0>
+pub declaration -> Node<Declaration<T>> = node<declaration0>
 
-declaration0 -> Declaration =
+declaration0 -> Declaration<T> =
     gnu<K<"__extension__">>? _ d:declaration1 _ ";" {
         Declaration {
             specifiers: d.0,
@@ -467,10 +469,10 @@ declaration0 -> Declaration =
 
 declaration_seq<h, t> = h:h _ t:t { (concat(h, t.0), t.1) }
 
-declaration1 -> (Vec<Node<DeclarationSpecifier>>, Vec<Node<InitDeclarator>>) =
+declaration1 -> (Vec<Node<DeclarationSpecifier<T>>>, Vec<Node<InitDeclarator<T>>>) =
     declaration_seq<declaration_specifiers_unique, declaration2>
 
-declaration2 -> (Vec<Node<DeclarationSpecifier>>, Vec<Node<InitDeclarator>>) =
+declaration2 -> (Vec<Node<DeclarationSpecifier<T>>>, Vec<Node<InitDeclarator<T>>>) =
     declaration_seq<declaration_typedef, declaration_typedef_tail> /
     declaration_seq<declaration_unique_type, declaration_tail<declaration_specifiers_unique>> /
     declaration_seq<declaration_nonunique_type, declaration_tail<declaration_specifiers_nonunique>>
@@ -482,59 +484,59 @@ declaration_tail1<s> =
     d:declaration_init_declarators { (Vec::new(), d) }
 
 // What can follow a typedef keyword
-declaration_typedef_tail -> (Vec<Node<DeclarationSpecifier>>, Vec<Node<InitDeclarator>>) =
+declaration_typedef_tail -> (Vec<Node<DeclarationSpecifier<T>>>, Vec<Node<InitDeclarator<T>>>) =
     declaration_seq<declaration_specifiers_unique, declaration_typedef_tail0>
 
-declaration_typedef_tail0 -> (Vec<Node<DeclarationSpecifier>>, Vec<Node<InitDeclarator>>) =
+declaration_typedef_tail0 -> (Vec<Node<DeclarationSpecifier<T>>>, Vec<Node<InitDeclarator<T>>>) =
     declaration_seq<declaration_unique_type, declaration_typedef_tail1<declaration_specifiers_unique>> /
     declaration_seq<declaration_nonunique_type, declaration_typedef_tail1<declaration_specifiers_nonunique>>
 
 // What can follow after typedef + type name
 declaration_typedef_tail1<s> = s:s _ d:declaration_type_declarators { (s, d) }
 
-declaration_unique_type -> Vec<Node<DeclarationSpecifier>> =
+declaration_unique_type -> Vec<Node<DeclarationSpecifier<T>>> =
     n:node<declaration_specifier_unique_type0> { vec![ n ] }
 
-declaration_nonunique_type -> Vec<Node<DeclarationSpecifier>> =
+declaration_nonunique_type -> Vec<Node<DeclarationSpecifier<T>>> =
     n:node<declaration_specifier_nonunique_type0> { vec![ n ] }
 
-declaration_specifiers -> Vec<Node<DeclarationSpecifier>> =
+declaration_specifiers -> Vec<Node<DeclarationSpecifier<T>>> =
     s:declaration_specifiers_unique _ t:declaration_specifiers_tail { concat(s, t) }
 
-declaration_specifiers_tail -> Vec<Node<DeclarationSpecifier>> =
+declaration_specifiers_tail -> Vec<Node<DeclarationSpecifier<T>>> =
     t:declaration_unique_type _ s:declaration_specifiers_unique { concat(t, s) } /
     t:declaration_nonunique_type _ s:declaration_specifiers_nonunique { concat(t, s) }
 
-declaration_specifiers_unique -> Vec<Node<DeclarationSpecifier>> =
+declaration_specifiers_unique -> Vec<Node<DeclarationSpecifier<T>>> =
     list0<node<declaration_specifier_nontype>>
 
-declaration_specifiers_nonunique  -> Vec<Node<DeclarationSpecifier>> =
+declaration_specifiers_nonunique  -> Vec<Node<DeclarationSpecifier<T>>> =
     list0<node<declaration_specifier_nontype / declaration_specifier_nonunique_type0>>
 
-declaration_specifier_nontype -> DeclarationSpecifier =
+declaration_specifier_nontype -> DeclarationSpecifier<T> =
     s:storage_class_specifier { DeclarationSpecifier::StorageClass(s) } /
     s:type_qualifier { DeclarationSpecifier::TypeQualifier(s) } /
     s:function_specifier { DeclarationSpecifier::Function(s) } /
     s:alignment_specifier { DeclarationSpecifier::Alignment(s) } /
     s:gnu<attribute_specifier> { DeclarationSpecifier::Extension(s) }
 
-declaration_typedef -> Vec<Node<DeclarationSpecifier>> =
+declaration_typedef -> Vec<Node<DeclarationSpecifier<T>>> =
     s:node<declaration_typedef0> { vec![ s ] }
 
-declaration_typedef0 -> DeclarationSpecifier =
+declaration_typedef0 -> DeclarationSpecifier<T> =
     s:storage_class_typedef { DeclarationSpecifier::StorageClass(s) }
 
-declaration_specifier_unique_type0 -> DeclarationSpecifier =
+declaration_specifier_unique_type0 -> DeclarationSpecifier<T> =
     s:node<type_specifier_unique> { DeclarationSpecifier::TypeSpecifier(s) }
 
-declaration_specifier_nonunique_type0 -> DeclarationSpecifier =
+declaration_specifier_nonunique_type0 -> DeclarationSpecifier<T> =
     s:node<type_specifier_nonunique> { DeclarationSpecifier::TypeSpecifier(s) }
 
-declaration_init_declarators -> Vec<Node<InitDeclarator>> = cs0<node<init_declarator>>
+declaration_init_declarators -> Vec<Node<InitDeclarator<T>>> = cs0<node<init_declarator>>
 
-declaration_type_declarators -> Vec<Node<InitDeclarator>> = cs0<node<type_declarator>>
+declaration_type_declarators -> Vec<Node<InitDeclarator<T>>> = cs0<node<type_declarator>>
 
-init_declarator -> InitDeclarator =
+init_declarator -> InitDeclarator<T> =
     d:init_declarator_declarator _ e:gnu<init_declarator_gnu>? _ i:node<init_declarator_init>?
     {
         InitDeclarator {
@@ -543,19 +545,19 @@ init_declarator -> InitDeclarator =
         }
     }
 
-init_declarator_declarator -> Node<Declarator> =
+init_declarator_declarator -> Node<Declarator<T>> =
     d:declarator {
         env.handle_declarator(&d, Symbol::Identifier);
         d
     }
 
-init_declarator_init -> Initializer =
+init_declarator_init -> Initializer<T> =
     "=" _ i:initializer { i }
 
-init_declarator_gnu -> Vec<Node<Extension>> =
+init_declarator_gnu -> Vec<Node<Extension<T>>> =
     l:asm_label? _ a:attribute_specifier_list { l.into_iter().chain(a).collect() }
 
-type_declarator -> InitDeclarator =
+type_declarator -> InitDeclarator<T> =
     d:declarator _ e:gnu<init_declarator_gnu>?
     {
         env.handle_declarator(&d, Symbol::Typename);
@@ -590,7 +592,7 @@ storage_class_typedef0 -> StorageClassSpecifier =
 // ISO 2011, 6.7.2, §2. Void, _Bool, _Atomic, typedef names, struct/unions, and enum
 // specifiers can only appear once in declaration specifiers or specifier-qualifiers.
 // This resolves the ambiguity with typedef names.
-type_specifier_unique -> TypeSpecifier =
+type_specifier_unique -> TypeSpecifier<T> =
     K<"void"> { TypeSpecifier::Void } /
     K<"_Bool"> { TypeSpecifier::Bool } /
     K<"_Atomic"> _ "(" _ t:type_name _ ")" { TypeSpecifier::Atomic(t) } /
@@ -598,7 +600,7 @@ type_specifier_unique -> TypeSpecifier =
     e:node<enum_specifier> { TypeSpecifier::Enum(e) } /
     t:typedef_name { TypeSpecifier::TypedefName(t) }
 
-type_specifier_nonunique -> TypeSpecifier =
+type_specifier_nonunique -> TypeSpecifier<T> =
     K<"char"> { TypeSpecifier::Char } /
     K<"short"> { TypeSpecifier::Short } /
     K<"int"> { TypeSpecifier::Int } /
@@ -611,7 +613,7 @@ type_specifier_nonunique -> TypeSpecifier =
     t:K<ts18661_float_type_specifier> { TypeSpecifier::TS18661Float(t) } /
     gnu<typeof_specifier>
 
-struct_or_union_specifier -> StructType =
+struct_or_union_specifier -> StructType<T> =
     t:node<struct_or_union> _ i:identifier? _ d:struct_or_union_body {
         StructType {
             kind: t,
@@ -627,7 +629,7 @@ struct_or_union_specifier -> StructType =
         }
     }
 
-struct_or_union_body -> Option<Vec<Node<StructDeclaration>>> =
+struct_or_union_body -> Option<Vec<Node<StructDeclaration<T>>>> =
     "{" _ d:list1<node<struct_declaration>> _ "}" { Some(d) } /
     gnu<"{" _ "}"> { Some(Vec::new()) } /
     { None }
@@ -636,12 +638,12 @@ struct_or_union -> StructKind =
     K<"struct"> { StructKind::Struct } /
     K<"union"> { StructKind::Union }
 
-struct_declaration -> StructDeclaration =
+struct_declaration -> StructDeclaration<T> =
     f:node<struct_field> { StructDeclaration::Field(f) } /
     s:static_assert { StructDeclaration::StaticAssert(s) } /
     gnu<K<"__extension__">> _ d:struct_declaration { d }
 
-struct_field -> StructField =
+struct_field -> StructField<T> =
     s:specifier_qualifiers _ d:cs0<node<struct_declarator>> _ ";" {
         StructField {
             specifiers: s,
@@ -649,20 +651,20 @@ struct_field -> StructField =
         }
     }
 
-specifier_qualifiers -> Vec<Node<SpecifierQualifier>> =
+specifier_qualifiers -> Vec<Node<SpecifierQualifier<T>>> =
     list_eq1_n<node<specifier_qualifier_unique_type0>, node<specifier_qualifier_qualifier0>> /
     list_ge1_n<node<specifier_qualifier_nonunique_type0>, node<specifier_qualifier_qualifier0>>
 
-specifier_qualifier_unique_type0 -> SpecifierQualifier =
+specifier_qualifier_unique_type0 -> SpecifierQualifier<T> =
     s:node<type_specifier_unique> { SpecifierQualifier::TypeSpecifier(s) }
 
-specifier_qualifier_nonunique_type0 -> SpecifierQualifier =
+specifier_qualifier_nonunique_type0 -> SpecifierQualifier<T> =
     s:node<type_specifier_nonunique> { SpecifierQualifier::TypeSpecifier(s) }
 
-specifier_qualifier_qualifier0 -> SpecifierQualifier =
+specifier_qualifier_qualifier0 -> SpecifierQualifier<T> =
     q:type_qualifier { SpecifierQualifier::TypeQualifier(q) }
 
-struct_declarator -> StructDeclarator =
+struct_declarator -> StructDeclarator<T> =
     d:declarator? _ ":" _ e:constant_expression a:gnu<attribute_specifier_list>? {
         StructDeclarator {
             declarator: d.map(|d| with_ext(d, a)),
@@ -676,7 +678,7 @@ struct_declarator -> StructDeclarator =
         }
     }
 
-enum_specifier -> EnumType =
+enum_specifier -> EnumType<T> =
     K<"enum"> _ i:identifier? _ "{" _ e:cs1<node<enumerator>> _ ","? _ "}" {
         EnumType {
             identifier: i,
@@ -690,16 +692,16 @@ enum_specifier -> EnumType =
         }
     }
 
-enumerator -> Enumerator =
+enumerator -> Enumerator<T> =
     i:identifier _ e:enumerator_constant? {
-        env.add_symbol(&i.node.name, Symbol::Identifier);
+        env.add_interned_symbol(&i.node.name, Symbol::Identifier);
         Enumerator {
             identifier: i,
             expression: e,
         }
     }
 
-enumerator_constant -> Box<Node<Expression>> =
+enumerator_constant -> Box<Node<Expression<T>>> =
     "=" _ e:constant_expression { e }
 
 ////
@@ -732,9 +734,9 @@ function_specifier0 -> FunctionSpecifier =
 // 6.7.5 Alignment specifiers
 ////
 
-alignment_specifier -> Node<AlignmentSpecifier> = node<alignment_specifier0>
+alignment_specifier -> Node<AlignmentSpecifier<T>> = node<alignment_specifier0>
 
-alignment_specifier0 -> AlignmentSpecifier =
+alignment_specifier0 -> AlignmentSpecifier<T> =
     K<"_Alignas"> _ "(" _ t:type_name _ ")" { AlignmentSpecifier::Type(t) } /
     K<"_Alignas"> _ "(" _ e:constant_expression _ ")" { AlignmentSpecifier::Constant(e) }
 
@@ -742,9 +744,9 @@ alignment_specifier0 -> AlignmentSpecifier =
 // 6.7.6 Declarators
 ////
 
-declarator -> Node<Declarator> = node<declarator0>
+declarator -> Node<Declarator<T>> = node<declarator0>
 
-declarator0 -> Declarator =
+declarator0 -> Declarator<T> =
     attr:gnu<attribute_specifier_list>?
     pointer:list0<pointer> _
     kind:node<direct_declarator> _
@@ -757,16 +759,16 @@ declarator0 -> Declarator =
         }
     }
 
-direct_declarator -> DeclaratorKind =
+direct_declarator -> DeclaratorKind<T> =
     i:identifier { DeclaratorKind::Identifier(i) } /
     "(" _ d:declarator _ ")" { DeclaratorKind::Declarator(Box::new(d)) }
 
-derived_declarator -> DerivedDeclarator =
+derived_declarator -> DerivedDeclarator<T> =
     "[" _ a:node<array_declarator> { DerivedDeclarator::Array(a) } /
     "(" _ f:scoped<node<function_declarator>> _ ")" { DerivedDeclarator::Function(f) } /
     "(" _ p:cs0<identifier> _ ")" { DerivedDeclarator::KRFunction(p) }
 
-array_declarator -> ArrayDeclarator =
+array_declarator -> ArrayDeclarator<T> =
     q:list0<type_qualifier> _ "]" {
         ArrayDeclarator {
             qualifiers: q,
@@ -798,7 +800,7 @@ array_declarator -> ArrayDeclarator =
         }
     }
 
-function_declarator -> FunctionDeclarator =
+function_declarator -> FunctionDeclarator<T> =
     p:cs1<parameter_declaration> _ e:ellipsis {
         FunctionDeclarator {
             parameters: p,
@@ -806,21 +808,21 @@ function_declarator -> FunctionDeclarator =
         }
     }
 
-pointer -> Node<DerivedDeclarator> = node<pointer0>
+pointer -> Node<DerivedDeclarator<T>> = node<pointer0>
 
-pointer0 -> DerivedDeclarator =
+pointer0 -> DerivedDeclarator<T> =
     "*" _ q:list0<node<pointer_qualifier>> { DerivedDeclarator::Pointer(q) }
 
-pointer_qualifier -> PointerQualifier =
+pointer_qualifier -> PointerQualifier<T> =
     q:type_qualifier { PointerQualifier::TypeQualifier(q) } /
     e:gnu<attribute_specifier> { PointerQualifier::Extension(e) }
 
 ellipsis -> Ellipsis =
     "," _ "..." { Ellipsis::Some } / { Ellipsis::None }
 
-parameter_declaration -> Node<ParameterDeclaration> = node<parameter_declaration0>
+parameter_declaration -> Node<ParameterDeclaration<T>> = node<parameter_declaration0>
 
-parameter_declaration0 -> ParameterDeclaration =
+parameter_declaration0 -> ParameterDeclaration<T> =
     s:declaration_specifiers _ d:parameter_declarator _ a:gnu<attribute_specifier_list>? {
         ParameterDeclaration {
             specifiers: s,
@@ -829,7 +831,7 @@ parameter_declaration0 -> ParameterDeclaration =
         }
     }
 
-parameter_declarator -> Option<Node<Declarator>> =
+parameter_declarator -> Option<Node<Declarator<T>>> =
     d:declarator {
         env.handle_declarator(&d, Symbol::Identifier);
         Some(d)
@@ -841,9 +843,9 @@ parameter_declarator -> Option<Node<Declarator>> =
 // 6.7.7 Type names
 ////
 
-type_name -> Node<TypeName> = node<type_name0>
+type_name -> Node<TypeName<T>> = node<type_name0>
 
-type_name0 -> TypeName =
+type_name0 -> TypeName<T> =
     s:specifier_qualifiers _ d:abstract_declarator? {
         TypeName {
             specifiers: s,
@@ -851,9 +853,9 @@ type_name0 -> TypeName =
         }
     }
 
-abstract_declarator -> Node<Declarator> = node<abstract_declarator0>
+abstract_declarator -> Node<Declarator<T>> = node<abstract_declarator0>
 
-abstract_declarator0 -> Declarator =
+abstract_declarator0 -> Declarator<T> =
     p:list0<pointer> _ k:node<direct_abstract_declarator> _ d:list0<derived_abstract_declarator> {
         Declarator {
             kind: k,
@@ -876,16 +878,16 @@ abstract_declarator0 -> Declarator =
         }
     }
 
-direct_abstract_declarator -> DeclaratorKind =
+direct_abstract_declarator -> DeclaratorKind<T> =
     "(" _ d:abstract_declarator _ ")" { DeclaratorKind::Declarator(Box::new(d)) }
 
-derived_abstract_declarator -> Node<DerivedDeclarator> = node<derived_abstract_declarator0>
+derived_abstract_declarator -> Node<DerivedDeclarator<T>> = node<derived_abstract_declarator0>
 
-derived_abstract_declarator0 -> DerivedDeclarator =
+derived_abstract_declarator0 -> DerivedDeclarator<T> =
     "[" _ a:node<abstract_array_declarator> { DerivedDeclarator::Array(a) } /
     "(" _ d:node<abstract_function_declarator> _ ")" { DerivedDeclarator::Function(d) }
 
-abstract_array_declarator -> ArrayDeclarator =
+abstract_array_declarator -> ArrayDeclarator<T> =
     q:list0<type_qualifier> _ "]" {
         ArrayDeclarator {
             qualifiers: q,
@@ -917,7 +919,7 @@ abstract_array_declarator -> ArrayDeclarator =
         }
     }
 
-abstract_function_declarator -> FunctionDeclarator =
+abstract_function_declarator -> FunctionDeclarator<T> =
     p:cs1<parameter_declaration> _ e:ellipsis {
         FunctionDeclarator {
             parameters: p,
@@ -936,9 +938,9 @@ abstract_function_declarator -> FunctionDeclarator =
 // 6.7.8 Type definitions
 ////
 
-typedef_name -> Node<Identifier> = #quiet<typedef_name0> / #expected("<typedef_name>")
+typedef_name -> Node<Identifier<T>> = #quiet<typedef_name0> / #expected("<typedef_name>")
 
-typedef_name0 -> Node<Identifier> = i:identifier {?
+typedef_name0 -> Node<Identifier<T>> = i:identifier {?
     if env.is_typename(&i.node.name) {
         Ok(i)
     } else {
@@ -950,12 +952,12 @@ typedef_name0 -> Node<Identifier> = i:identifier {?
 // 6.7.9 Initialization
 ////
 
-initializer -> Initializer =
+initializer -> Initializer<T> =
     e:assignment_expression { Initializer::Expression(e) } /
     "{" _ i:cs1<node<initializer_list_item>> _ ","? _ "}" { Initializer::List(i) } /
     gnu<"{" _ "}"> { Initializer::List(Vec::new()) }
 
-initializer_list_item -> InitializerListItem =
+initializer_list_item -> InitializerListItem<T> =
     d:designation? _ i:node<initializer> {
         InitializerListItem {
             designation: d.unwrap_or_default(),
@@ -963,19 +965,19 @@ initializer_list_item -> InitializerListItem =
         }
     }
 
-designation -> Vec<Node<Designator>> =
+designation -> Vec<Node<Designator<T>>> =
     d:list1<node<designator>> _ "=" { d } /
     d:gnu<node<colon_designation>> { vec! [ d ] } /
     d:gnu<node<array_designator>> { vec![ d ] }
 
-colon_designation -> Designator =
+colon_designation -> Designator<T> =
     i:identifier _ ":" { Designator::Member(i) }
 
-designator -> Designator =
+designator -> Designator<T> =
     d:array_designator { d } /
     "." _ i:identifier { Designator::Member(i) }
 
-array_designator -> Designator =
+array_designator -> Designator<T> =
     "[" _ a:node<constant_expression0> _ b:gnu<range_designator_ext>? "]" {
         match b {
             Some(b) => {
@@ -986,16 +988,16 @@ array_designator -> Designator =
         }
     }
 
-range_designator_ext -> Node<Expression> =
+range_designator_ext -> Node<Expression<T>> =
     "..." _ e:node<constant_expression0> { e }
 
 ////
 // 6.7.10 Static assertions
 ////
 
-static_assert -> Node<StaticAssert> = node<static_assert0>
+static_assert -> Node<StaticAssert<T>> = node<static_assert0>
 
-static_assert0 -> StaticAssert =
+static_assert0 -> StaticAssert<T> =
    gnu<K<"__extension__">>?
    _ K<"_Static_assert"> _ "(" _ e:constant_expression _ "," _ s:string_literal _ ")" _ ";" {
         StaticAssert {
@@ -1008,9 +1010,9 @@ static_assert0 -> StaticAssert =
 // 6.8 Statements and blocks
 ////
 
-pub statement -> Box<Node<Statement>> = box<node<statement0>>
+pub statement -> Box<Node<Statement<T>>> = box<node<statement0>>
 
-statement0 -> Statement =
+statement0 -> Statement<T> =
     s:node<labeled_statement> { Statement::Labeled(s) } /
     scoped<compound_statement> /
     expression_statement /
@@ -1023,7 +1025,7 @@ statement0 -> Statement =
 // 6.8.1 Labeled statements
 ////
 
-labeled_statement -> LabeledStatement =
+labeled_statement -> LabeledStatement<T> =
     l:node<label> _ ":" _ s:statement {
         LabeledStatement {
             label: l,
@@ -1031,7 +1033,7 @@ labeled_statement -> LabeledStatement =
         }
     }
 
-label -> Label =
+label -> Label<T> =
     i:identifier { Label::Identifier(i) } /
     K<"case"> _ e:constant_expression { Label::Case(e) } /
     K<"default"> { Label::Default }
@@ -1040,30 +1042,30 @@ label -> Label =
 // 6.8.2 Compound statement
 ////
 
-compound_statement -> Statement =
+compound_statement -> Statement<T> =
     "{" _ b:list0<node<block_item>> _ "}" { Statement::Compound(b) }
 
-block_item -> BlockItem =
+block_item -> BlockItem<T> =
     d:declaration { BlockItem::Declaration(d) } /
     s:static_assert { BlockItem::StaticAssert(s) } /
     s:node<statement0> { BlockItem::Statement(s) }
 
 ////
-// 6.8.3 Expression and null statements
+// 6.8.3 Expression<T> and null statements
 ////
 
-expression_statement -> Statement =
+expression_statement -> Statement<T> =
     e:expression? _ ";" { Statement::Expression(e) }
 
 ////
 // 6.8.4 Selection statement
 ////
 
-selection_statement -> Statement =
+selection_statement -> Statement<T> =
     s:node<if_statement> { Statement::If(s) } /
     s:node<switch_statement> { Statement::Switch(s) }
 
-if_statement -> IfStatement =
+if_statement -> IfStatement<T> =
     K<"if"> _ "(" _ e:expression _ ")" _ a:statement _ b:else_statement? {
         IfStatement {
             condition: e,
@@ -1072,9 +1074,9 @@ if_statement -> IfStatement =
         }
     }
 
-else_statement -> Box<Node<Statement>> = K<"else"> _ s:statement { s }
+else_statement -> Box<Node<Statement<T>>> = K<"else"> _ s:statement { s }
 
-switch_statement -> SwitchStatement =
+switch_statement -> SwitchStatement<T> =
     K<"switch"> _ "(" _ e:expression _ ")" _ s:statement {
         SwitchStatement {
             expression: e,
@@ -1086,12 +1088,12 @@ switch_statement -> SwitchStatement =
 // 6.8.5 Iteration statement
 ////
 
-iteration_statement -> Statement =
+iteration_statement -> Statement<T> =
     s:node<while_statement> { Statement::While(s) } /
     s:node<do_while_statement> { Statement::DoWhile(s) } /
     s:node<for_statement> { Statement::For(s) }
 
-while_statement -> WhileStatement =
+while_statement -> WhileStatement<T> =
     K<"while"> _ "(" _ e:expression _ ")" _ s:statement {
         WhileStatement {
             expression: e,
@@ -1099,7 +1101,7 @@ while_statement -> WhileStatement =
         }
     }
 
-do_while_statement -> DoWhileStatement =
+do_while_statement -> DoWhileStatement<T> =
     K<"do"> _ s:statement _ K<"while"> _ "(" _ e:expression _ ")" _ ";" {
         DoWhileStatement {
             statement: s,
@@ -1107,7 +1109,7 @@ do_while_statement -> DoWhileStatement =
         }
     }
 
-for_statement -> ForStatement =
+for_statement -> ForStatement<T> =
     K<"for"> _ "(" _ a:node<for_initializer> _ b:expression? _ ";" _ c:expression? _ ")" _ s:statement {
         ForStatement {
             initializer: a,
@@ -1117,7 +1119,7 @@ for_statement -> ForStatement =
         }
     }
 
-for_initializer -> ForInitializer =
+for_initializer -> ForInitializer<T> =
     e:expression _ ";" { ForInitializer::Expression(e) } /
     d:declaration { ForInitializer::Declaration(d) } /
     s:static_assert { ForInitializer::StaticAssert(s) } /
@@ -1127,7 +1129,7 @@ for_initializer -> ForInitializer =
 // 6.8.6 Jump statements
 ////
 
-jump_statement -> Statement =
+jump_statement -> Statement<T> =
     K<"goto"> _ i:identifier _ ";" { Statement::Goto(i) } /
     K<"continue"> _ ";" { Statement::Continue } /
     K<"break"> _ ";" { Statement::Break } /
@@ -1139,15 +1141,15 @@ jump_statement -> Statement =
 
 scoped<e> = ({ env.enter_scope(); }) e:e? {? env.leave_scope(); e.ok_or("") }
 
-pub translation_unit -> TranslationUnit =
+pub translation_unit -> TranslationUnit<T> =
     directive? _ d:list0<node<external_declaration>> _ { TranslationUnit(d) }
 
-external_declaration -> ExternalDeclaration =
+external_declaration -> ExternalDeclaration<T> =
     d:declaration { ExternalDeclaration::Declaration(d) } /
     s:static_assert { ExternalDeclaration::StaticAssert(s) } /
     d:scoped<node<function_definition>> { ExternalDeclaration::FunctionDefinition(d) }
 
-function_definition -> FunctionDefinition =
+function_definition -> FunctionDefinition<T> =
     gnu<K<"__extension__">>?
     _ a:declaration_specifiers _ b:declarator _ c:list0<declaration>
     _ d:node<compound_statement> {
@@ -1171,13 +1173,13 @@ gnu_guard = {? if env.extensions_gnu { Ok(()) } else { Err("gnu extensions disab
 // GNU attributes
 ////
 
-attribute_specifier_list -> Vec<Node<Extension>> =
+attribute_specifier_list -> Vec<Node<Extension<T>>> =
     a:list0<attribute_specifier> { a.into_iter().flat_map(|v| v).collect() }
 
-attribute_specifier -> Vec<Node<Extension>> =
+attribute_specifier -> Vec<Node<Extension<T>>> =
     K<"__attribute__"> _ "((" _ a:cs0<node<attribute>> _ "))" { a }
 
-attribute -> Extension =
+attribute -> Extension<T> =
     c:clang<node<attr_availability>> { Extension::AvailabilityAttribute(c) } /
     n:node<attribute_name> _ p:attribute_parameters? {
         Extension::Attribute(Attribute {
@@ -1189,10 +1191,10 @@ attribute -> Extension =
 attribute_name -> String =
     n:$(#quiet<[_a-zA-Z][_a-zA-Z0-9]*>) { String::from(n) }
 
-attribute_parameters -> Vec<Node<Expression>> =
+attribute_parameters -> Vec<Node<Expression<T>>> =
     "(" _ e:cs0<node<assignment_expression0>> _ ")" { e }
 
-attr_availability -> AvailabilityAttribute =
+attr_availability -> AvailabilityAttribute<T> =
     K<"availability"> _ "(" _ p:identifier _ "," _ c:cs1<node<attr_availability_clause>> _ ")" {
         AvailabilityAttribute {
             platform: p,
@@ -1221,9 +1223,9 @@ attr_availability_version -> AvailabilityVersion =
 // GNU assembler labels
 ////
 
-asm_label -> Node<Extension> = node<asm_label0>
+asm_label -> Node<Extension<T>> = node<asm_label0>
 
-asm_label0 -> Extension =
+asm_label0 -> Extension<T> =
     asm_label_keyword _ "(" _ s:string_literal _ ")" { Extension::AsmLabel(s) }
 
 asm_label_keyword =
@@ -1233,10 +1235,10 @@ asm_label_keyword =
 // GNU assembler statements
 ////
 
-asm_statement -> Statement =
+asm_statement -> Statement<T> =
     s:node<asm_statement0> { Statement::Asm(s) }
 
-asm_statement0 -> AsmStatement =
+asm_statement0 -> AsmStatement<T> =
     K<"asm" / "__asm" "__"?> _ q:type_qualifier? _ "(" _
         a:string_literal _
         o:asm_ext<asm_operand_list, asm_ext<asm_operand_list, asm_ext<cs0<string_literal>, ()>>>? _
@@ -1256,9 +1258,9 @@ asm_statement0 -> AsmStatement =
 
 asm_ext<e, t> = ":" _ e:e _ t:t? { (e, t.unwrap_or_default()) }
 
-asm_operand_list -> Vec<Node<GnuAsmOperand>> = cs0<node<asm_operand>>
+asm_operand_list -> Vec<Node<GnuAsmOperand<T>>> = cs0<node<asm_operand>>
 
-asm_operand -> GnuAsmOperand =
+asm_operand -> GnuAsmOperand<T> =
     i:("[" _ i:identifier _ "]" _ {i})? s:string_literal _ "(" _ e:node<expression0> _ ")" {
         GnuAsmOperand {
             symbolic_name: i,
@@ -1271,19 +1273,19 @@ asm_operand -> GnuAsmOperand =
 // GNU expression extensions
 ////
 
-gnu_primary_expression -> Expression =
+gnu_primary_expression -> Expression<T> =
     statement_expression /
     offsetof_expression /
     va_arg_expression /
     keyword_expression
 
-statement_expression -> Expression =
+statement_expression -> Expression<T> =
     "(" _ s:scoped<node<compound_statement>> _ ")" { Expression::Statement(Box::new(s)) }
 
-va_arg_expression -> Expression =
+va_arg_expression -> Expression<T> =
     n:node<va_arg_expression_inner> { Expression::VaArg(Box::new(n)) }
 
-va_arg_expression_inner -> VaArgExpression =
+va_arg_expression_inner -> VaArgExpression<T> =
     K<"__builtin_va_arg"> _ "(" _ e:assignment_expression _ "," _ t:type_name _ ")" {
         VaArgExpression {
             va_list: e,
@@ -1291,10 +1293,10 @@ va_arg_expression_inner -> VaArgExpression =
         }
     }
 
-keyword_expression -> Expression =
+keyword_expression -> Expression<T> =
     k:node<$(keyword_expression0)> {
         let ident = Identifier {
-            name: k.node.to_string(),
+            name: T::get_from_str(k.node),
         };
         Expression::Identifier(Box::new(Node::new(ident, k.span)))
     }
@@ -1304,10 +1306,10 @@ keyword_expression0 =
     K<"__FUNCTION__"> /
     K<"__PRETTY_FUNCTION__">
 
-offsetof_expression -> Expression =
+offsetof_expression -> Expression<T> =
     n:node<offsetof_expression_inner> { Expression::OffsetOf(Box::new(n)) }
 
-offsetof_expression_inner -> OffsetOfExpression =
+offsetof_expression_inner -> OffsetOfExpression<T> =
     K<"__builtin_offsetof"> _ "(" _ t:type_name _ "," _ d:node<offsetof_designator> _ ")" {
         OffsetOfExpression {
             type_name: t,
@@ -1315,7 +1317,7 @@ offsetof_expression_inner -> OffsetOfExpression =
         }
     }
 
-offsetof_designator -> OffsetDesignator =
+offsetof_designator -> OffsetDesignator<T> =
     i:identifier _ d:list0<node<offsetof_member>> {
         OffsetDesignator {
             base: i,
@@ -1323,7 +1325,7 @@ offsetof_designator -> OffsetDesignator =
         }
     }
 
-offsetof_member -> OffsetMember =
+offsetof_member -> OffsetMember<T> =
     "." _ i:identifier { OffsetMember::Member(i) } /
     "->" _ i:identifier { OffsetMember::IndirectMember(i) } /
     "[" _ e:node<expression0> _ "]" { OffsetMember::Index(e) }
@@ -1332,10 +1334,10 @@ offsetof_member -> OffsetMember =
 // GNU typeof extension
 ////
 
-typeof_specifier -> TypeSpecifier =
+typeof_specifier -> TypeSpecifier<T> =
     K<"typeof" / "__typeof" "__"?> _ "(" _ e:node<typeof_specifier0> _ ")" { TypeSpecifier::TypeOf(e) }
 
-typeof_specifier0 -> TypeOf =
+typeof_specifier0 -> TypeOf<T> =
     e:node<expression0> { TypeOf::Expression(e) } /
     t:type_name { TypeOf::Type(t) }
 

--- a/grammar.sed
+++ b/grammar.sed
@@ -1,0 +1,5 @@
+s/struct ParseState < 'input >/struct ParseState<'input, T: Name>/g;
+s/< 'input > (/<'input, T: Name>(/g;
+s/ParseState < 'input >/ParseState<'input, T>/g;
+s/impl < 'input >/impl<'input, T: Name>/g;
+s/ParseState,/ParseState<'_, impl Name>,/g;

--- a/src/astutil.rs
+++ b/src/astutil.rs
@@ -47,7 +47,10 @@ fn apply_op<T: Name>(a: Node<Expression<T>>, op: Node<Operation<T>>) -> Node<Exp
     Node::new(expr, span)
 }
 
-pub fn apply_ops<T: Name>(ops: Vec<Node<Operation<T>>>, expr: Node<Expression<T>>) -> Node<Expression<T>> {
+pub fn apply_ops<T: Name>(
+    ops: Vec<Node<Operation<T>>>,
+    expr: Node<Expression<T>>,
+) -> Node<Expression<T>> {
     ops.into_iter().fold(expr, apply_op)
 }
 
@@ -76,7 +79,10 @@ pub fn infix<T: Name>(
     )
 }
 
-pub fn with_ext<T: Name>(mut d: Node<Declarator<T>>, e: Option<Vec<Node<Extension<T>>>>) -> Node<Declarator<T>> {
+pub fn with_ext<T: Name>(
+    mut d: Node<Declarator<T>>,
+    e: Option<Vec<Node<Extension<T>>>>,
+) -> Node<Declarator<T>> {
     if let Some(e) = e {
         d.node.extensions.extend(e);
     }

--- a/src/astutil.rs
+++ b/src/astutil.rs
@@ -2,14 +2,14 @@ use ast::*;
 use span::{Node, Span};
 
 #[cfg_attr(test, derive(Debug, PartialEq, Clone))]
-pub enum Operation {
-    Member(Node<MemberOperator>, Node<Identifier>),
+pub enum Operation<T: Name> {
+    Member(Node<MemberOperator>, Node<Identifier<T>>),
     Unary(Node<UnaryOperator>),
-    Binary(Node<BinaryOperator>, Node<Expression>),
-    Call(Vec<Node<Expression>>),
+    Binary(Node<BinaryOperator>, Node<Expression<T>>),
+    Call(Vec<Node<Expression<T>>>),
 }
 
-fn apply_op(a: Node<Expression>, op: Node<Operation>) -> Node<Expression> {
+fn apply_op<T: Name>(a: Node<Expression<T>>, op: Node<Operation<T>>) -> Node<Expression<T>> {
     let span = Span::span(a.span.start, op.span.end);
     let expr = match op.node {
         Operation::Member(op, id) => Expression::Member(Box::new(Node::new(
@@ -47,7 +47,7 @@ fn apply_op(a: Node<Expression>, op: Node<Operation>) -> Node<Expression> {
     Node::new(expr, span)
 }
 
-pub fn apply_ops(ops: Vec<Node<Operation>>, expr: Node<Expression>) -> Node<Expression> {
+pub fn apply_ops<T: Name>(ops: Vec<Node<Operation<T>>>, expr: Node<Expression<T>>) -> Node<Expression<T>> {
     ops.into_iter().fold(expr, apply_op)
 }
 
@@ -56,12 +56,12 @@ pub fn concat<T>(mut a: Vec<T>, b: Vec<T>) -> Vec<T> {
     a
 }
 
-pub fn infix(
+pub fn infix<T: Name>(
     node: Node<()>,
     op: BinaryOperator,
-    lhs: Node<Expression>,
-    rhs: Node<Expression>,
-) -> Node<Expression> {
+    lhs: Node<Expression<T>>,
+    rhs: Node<Expression<T>>,
+) -> Node<Expression<T>> {
     let span = Span::span(lhs.span.start, rhs.span.end);
     Node::new(
         Expression::BinaryOperator(Box::new(Node::new(
@@ -76,7 +76,7 @@ pub fn infix(
     )
 }
 
-pub fn with_ext(mut d: Node<Declarator>, e: Option<Vec<Node<Extension>>>) -> Node<Declarator> {
+pub fn with_ext<T: Name>(mut d: Node<Declarator<T>>, e: Option<Vec<Node<Extension<T>>>>) -> Node<Declarator<T>> {
     if let Some(e) = e {
         d.node.extensions.extend(e);
     }

--- a/src/bin/meminfo.rs
+++ b/src/bin/meminfo.rs
@@ -3,58 +3,62 @@ use lang_c::ast::*;
 use std::mem::size_of;
 
 macro_rules! ps {
-    ($( $i:ident )+) => ({ $(println!("{:3}  {}", size_of::<$i>(), stringify!($i));)+ })
+    ($( $t:ty )+) => ({ $(println!("{:3}  {}", size_of::<$t>(), stringify!($t));)+ })
 }
 
-fn main() {
+fn print_all<T: Name>() {
     ps! {
-        TypeOf
-        Identifier
+        TypeOf<T>
+        Identifier<T>
         Constant
         Integer
         Float
-        Expression
+        Expression<T>
         MemberOperator
-        GenericAssociation
+        GenericAssociation<T>
         UnaryOperator
         BinaryOperator
-        OffsetDesignator
-        OffsetMember
-        Declaration
-        DeclarationSpecifier
-        InitDeclarator
+        OffsetDesignator<T>
+        OffsetMember<T>
+        Declaration<T>
+        DeclarationSpecifier<T>
+        InitDeclarator<T>
         StorageClassSpecifier
-        TypeSpecifier
-        StructType
-        StructDeclaration
-        SpecifierQualifier
-        StructDeclarator
-        Enumerator
+        TypeSpecifier<T>
+        StructType<T>
+        StructDeclaration<T>
+        SpecifierQualifier<T>
+        StructDeclarator<T>
+        Enumerator<T>
         TypeQualifier
         FunctionSpecifier
-        AlignmentSpecifier
-        Declarator
-        DeclaratorKind
-        DerivedDeclarator
-        PointerQualifier
-        ArraySize
-        ParameterDeclaration
+        AlignmentSpecifier<T>
+        Declarator<T>
+        DeclaratorKind<T>
+        DerivedDeclarator<T>
+        PointerQualifier<T>
+        ArraySize<T>
+        ParameterDeclaration<T>
         Ellipsis
-        TypeName
-        Initializer
-        InitializerListItem
-        Designator
-        StaticAssert
-        Statement
-        Label
-        ForInitializer
-        BlockItem
-        TranslationUnit
-        ExternalDeclaration
-        FunctionDefinition
-        Extension
-        AsmStatement
-        GnuAsmOperand
-        TypeOf
+        TypeName<T>
+        Initializer<T>
+        InitializerListItem<T>
+        Designator<T>
+        StaticAssert<T>
+        Statement<T>
+        Label<T>
+        ForInitializer<T>
+        BlockItem<T>
+        TranslationUnit<T>
+        ExternalDeclaration<T>
+        FunctionDefinition<T>
+        Extension<T>
+        AsmStatement<T>
+        GnuAsmOperand<T>
+        TypeOf<T>
     }
+}
+
+fn main () {
+    print_all::<String>();
 }

--- a/src/bin/meminfo.rs
+++ b/src/bin/meminfo.rs
@@ -6,59 +6,55 @@ macro_rules! ps {
     ($( $t:ty )+) => ({ $(println!("{:3}  {}", size_of::<$t>(), stringify!($t));)+ })
 }
 
-fn print_all<T: Name>() {
+fn main() {
     ps! {
-        TypeOf<T>
-        Identifier<T>
+        TypeOf
+        Identifier
         Constant
         Integer
         Float
-        Expression<T>
+        Expression
         MemberOperator
-        GenericAssociation<T>
+        GenericAssociation
         UnaryOperator
         BinaryOperator
-        OffsetDesignator<T>
-        OffsetMember<T>
-        Declaration<T>
-        DeclarationSpecifier<T>
-        InitDeclarator<T>
+        OffsetDesignator
+        OffsetMember
+        Declaration
+        DeclarationSpecifier
+        InitDeclarator
         StorageClassSpecifier
-        TypeSpecifier<T>
-        StructType<T>
-        StructDeclaration<T>
-        SpecifierQualifier<T>
-        StructDeclarator<T>
-        Enumerator<T>
+        TypeSpecifier
+        StructType
+        StructDeclaration
+        SpecifierQualifier
+        StructDeclarator
+        Enumerator
         TypeQualifier
         FunctionSpecifier
-        AlignmentSpecifier<T>
-        Declarator<T>
-        DeclaratorKind<T>
-        DerivedDeclarator<T>
-        PointerQualifier<T>
-        ArraySize<T>
-        ParameterDeclaration<T>
+        AlignmentSpecifier
+        Declarator
+        DeclaratorKind
+        DerivedDeclarator
+        PointerQualifier
+        ArraySize
+        ParameterDeclaration
         Ellipsis
-        TypeName<T>
-        Initializer<T>
-        InitializerListItem<T>
-        Designator<T>
-        StaticAssert<T>
-        Statement<T>
-        Label<T>
-        ForInitializer<T>
-        BlockItem<T>
-        TranslationUnit<T>
-        ExternalDeclaration<T>
-        FunctionDefinition<T>
-        Extension<T>
-        AsmStatement<T>
-        GnuAsmOperand<T>
-        TypeOf<T>
+        TypeName
+        Initializer
+        InitializerListItem
+        Designator
+        StaticAssert
+        Statement
+        Label
+        ForInitializer
+        BlockItem
+        TranslationUnit
+        ExternalDeclaration
+        FunctionDefinition
+        Extension
+        AsmStatement
+        GnuAsmOperand
+        TypeOf
     }
-}
-
-fn main() {
-    print_all::<String>();
 }

--- a/src/bin/meminfo.rs
+++ b/src/bin/meminfo.rs
@@ -59,6 +59,6 @@ fn print_all<T: Name>() {
     }
 }
 
-fn main () {
+fn main() {
     print_all::<String>();
 }

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -8,8 +8,10 @@ use std::path::Path;
 use std::process::Command;
 
 use ast::TranslationUnit;
+use ast::Name;
 use env::Env;
 use parser::translation_unit;
+
 
 /// Parser configuration
 #[derive(Clone, Debug)]
@@ -67,11 +69,11 @@ pub enum Flavor {
 
 /// Result of a successful parse
 #[derive(Clone, Debug)]
-pub struct Parse {
+pub struct Parse<T: Name = String> {
     /// Pre-processed source text
     pub source: String,
     /// Root of the abstract syntax tree
-    pub unit: TranslationUnit,
+    pub unit: TranslationUnit<T>,
 }
 
 #[derive(Debug)]
@@ -149,15 +151,26 @@ impl fmt::Display for SyntaxError {
 
 /// Parse a C file
 pub fn parse<P: AsRef<Path>>(config: &Config, source: P) -> Result<Parse, Error> {
+    parse_ext(config, source)
+}
+
+/// Parse a C file using a custom type for identifiers (e.g. interned string)
+pub fn parse_ext<P: AsRef<Path>, T: Name>(config: &Config, source: P) -> Result<Parse<T>, Error> {
     let processed = match preprocess(config, source.as_ref()) {
         Ok(s) => s,
         Err(e) => return Err(Error::PreprocessorError(e)),
     };
 
-    Ok(try!(parse_preprocessed(config, processed)))
+    Ok(try!(parse_preprocessed_ext(config, processed)))
 }
 
+/// Parse Preprocessed Code in String
 pub fn parse_preprocessed(config: &Config, source: String) -> Result<Parse, SyntaxError> {
+    parse_preprocessed_ext(config, source)
+}
+
+/// Parse Preprocessed Code in String using a custom type for identifiers (e.g. interned string)
+pub fn parse_preprocessed_ext<T: Name>(config: &Config, source: String) -> Result<Parse<T>, SyntaxError> {
     let mut env = match config.flavor {
         Flavor::StdC11 => Env::with_core(),
         Flavor::GnuC11 => Env::with_gnu(),

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -7,11 +7,10 @@ use std::io;
 use std::path::Path;
 use std::process::Command;
 
-use ast::TranslationUnit;
 use ast::Name;
+use ast::TranslationUnit;
 use env::Env;
 use parser::translation_unit;
-
 
 /// Parser configuration
 #[derive(Clone, Debug)]
@@ -170,7 +169,10 @@ pub fn parse_preprocessed(config: &Config, source: String) -> Result<Parse, Synt
 }
 
 /// Parse Preprocessed Code in String using a custom type for identifiers (e.g. interned string)
-pub fn parse_preprocessed_ext<T: Name>(config: &Config, source: String) -> Result<Parse<T>, SyntaxError> {
+pub fn parse_preprocessed_ext<T: Name>(
+    config: &Config,
+    source: String,
+) -> Result<Parse<T>, SyntaxError> {
     let mut env = match config.flavor {
         Flavor::StdC11 => Env::with_core(),
         Flavor::GnuC11 => Env::with_gnu(),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -30,16 +30,16 @@ pub struct ParseError {
 pub type ParseResult<T> = Result<T, ParseError>;
 impl ::std::fmt::Display for ParseError {
     fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::result::Result<(), ::std::fmt::Error> {
-        try!(write!(fmt, "error at {}:{}: expected ", self.line, self.column));
+        write!(fmt, "error at {}:{}: expected ", self.line, self.column)?;
         if self.expected.len() == 0 {
-            try!(write!(fmt, "EOF"));
+            write!(fmt, "EOF")?;
         } else if self.expected.len() == 1 {
-            try!(write!(fmt, "`{}`", escape_default(self.expected.iter().next().unwrap())));
+            write!(fmt, "`{}`", escape_default(self.expected.iter().next().unwrap()))?;
         } else {
             let mut iter = self.expected.iter();
-            try!(write!(fmt, "one of `{}`", escape_default(iter.next().unwrap())));
+            write!(fmt, "one of `{}`", escape_default(iter.next().unwrap()))?;
             for elem in iter {
-                try!(write!(fmt, ", `{}`", escape_default(elem)));
+                write!(fmt, ", `{}`", escape_default(elem))?;
             }
         }
         Ok(())
@@ -50,7 +50,7 @@ impl ::std::error::Error for ParseError {
         "parse error"
     }
 }
-fn slice_eq(input: &str, state: &mut ParseState, pos: usize, m: &'static str) -> RuleResult<()> {
+fn slice_eq(input: &str, state: &mut ParseState<'_, impl Name>, pos: usize, m: &'static str) -> RuleResult<()> {
     #![inline]
     #![allow(dead_code)]
     let l = m.len();
@@ -60,7 +60,7 @@ fn slice_eq(input: &str, state: &mut ParseState, pos: usize, m: &'static str) ->
         state.mark_failure(pos, m)
     }
 }
-fn slice_eq_case_insensitive(input: &str, state: &mut ParseState, pos: usize, m: &'static str) -> RuleResult<()> {
+fn slice_eq_case_insensitive(input: &str, state: &mut ParseState<'_, impl Name>, pos: usize, m: &'static str) -> RuleResult<()> {
     #![inline]
     #![allow(dead_code)]
     let mut used = 0usize;
@@ -74,7 +74,7 @@ fn slice_eq_case_insensitive(input: &str, state: &mut ParseState, pos: usize, m:
     }
     Matched(pos + used, ())
 }
-fn any_char(input: &str, state: &mut ParseState, pos: usize) -> RuleResult<()> {
+fn any_char(input: &str, state: &mut ParseState<'_, impl Name>, pos: usize) -> RuleResult<()> {
     #![inline]
     #![allow(dead_code)]
     if input.len() > pos {
@@ -90,7 +90,7 @@ fn pos_to_line(input: &str, pos: usize) -> (usize, usize) {
     let col = before.chars().rev().take_while(|&c| c != '\n').count() + 1;
     (line, col)
 }
-impl<'input> ParseState<'input> {
+impl<'input, T: Name> ParseState<'input, T> {
     fn mark_failure(&mut self, pos: usize, expected: &'static str) -> RuleResult<()> {
         if self.suppress_fail == 0 {
             if pos > self.max_err_pos {
@@ -104,20 +104,20 @@ impl<'input> ParseState<'input> {
         Failed
     }
 }
-struct ParseState<'input> {
+struct ParseState<'input, T: Name> {
     max_err_pos: usize,
     suppress_fail: usize,
     expected: ::std::collections::HashSet<&'static str>,
     _phantom: ::std::marker::PhantomData<&'input ()>,
-    postfix_expression0_cache: ::std::collections::HashMap<usize, RuleResult<Expression>>,
+    postfix_expression0_cache: ::std::collections::HashMap<usize, RuleResult<Expression<T>>>,
 }
-impl<'input> ParseState<'input> {
-    fn new() -> ParseState<'input> {
+impl<'input, T: Name> ParseState<'input, T> {
+    fn new() -> ParseState<'input, T> {
         ParseState { max_err_pos: 0, suppress_fail: 0, expected: ::std::collections::HashSet::new(), _phantom: ::std::marker::PhantomData, postfix_expression0_cache: ::std::collections::HashMap::new() }
     }
 }
 
-fn __parse__<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<()> {
+fn __parse__<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<()> {
     #![allow(non_snake_case, unused)]
     {
         __state.suppress_fail += 1;
@@ -176,7 +176,7 @@ fn __parse__<'input>(__input: &'input str, __state: &mut ParseState<'input>, __p
     }
 }
 
-fn __parse_directive<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<()> {
+fn __parse_directive<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<()> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = slice_eq(__input, __state, __pos, "#");
@@ -210,7 +210,7 @@ fn __parse_directive<'input>(__input: &'input str, __state: &mut ParseState<'inp
     }
 }
 
-fn __parse_identifier<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Node<Identifier>> {
+fn __parse_identifier<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Node<Identifier<T>>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = Matched(__pos, __pos);
@@ -233,7 +233,7 @@ fn __parse_identifier<'input>(__input: &'input str, __state: &mut ParseState<'in
     }
 }
 
-fn __parse_identifier0<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Identifier> {
+fn __parse_identifier0<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Identifier<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -284,7 +284,7 @@ fn __parse_identifier0<'input>(__input: &'input str, __state: &mut ParseState<'i
             Matched(__pos, n) => {
                 match {
                     if !env.reserved.contains(n) {
-                        Ok(Identifier { name: n.into() })
+                        Ok(Identifier { name: T::get_from_str(n) })
                     } else {
                         Err("identifier")
                     }
@@ -301,7 +301,7 @@ fn __parse_identifier0<'input>(__input: &'input str, __state: &mut ParseState<'i
     }
 }
 
-fn __parse_ohx<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<()> {
+fn __parse_ohx<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<()> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = slice_eq(__input, __state, __pos, "0");
@@ -322,7 +322,7 @@ fn __parse_ohx<'input>(__input: &'input str, __state: &mut ParseState<'input>, _
     }
 }
 
-fn __parse_obb<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<()> {
+fn __parse_obb<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<()> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = slice_eq(__input, __state, __pos, "0");
@@ -343,7 +343,7 @@ fn __parse_obb<'input>(__input: &'input str, __state: &mut ParseState<'input>, _
     }
 }
 
-fn __parse_dec<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<()> {
+fn __parse_dec<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<()> {
     #![allow(non_snake_case, unused)]
     if __input.len() > __pos {
         let (__ch, __next) = char_range_at(__input, __pos);
@@ -356,7 +356,7 @@ fn __parse_dec<'input>(__input: &'input str, __state: &mut ParseState<'input>, _
     }
 }
 
-fn __parse_oct<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<()> {
+fn __parse_oct<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<()> {
     #![allow(non_snake_case, unused)]
     if __input.len() > __pos {
         let (__ch, __next) = char_range_at(__input, __pos);
@@ -369,7 +369,7 @@ fn __parse_oct<'input>(__input: &'input str, __state: &mut ParseState<'input>, _
     }
 }
 
-fn __parse_hex<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<()> {
+fn __parse_hex<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<()> {
     #![allow(non_snake_case, unused)]
     if __input.len() > __pos {
         let (__ch, __next) = char_range_at(__input, __pos);
@@ -382,7 +382,7 @@ fn __parse_hex<'input>(__input: &'input str, __state: &mut ParseState<'input>, _
     }
 }
 
-fn __parse_bin<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<()> {
+fn __parse_bin<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<()> {
     #![allow(non_snake_case, unused)]
     if __input.len() > __pos {
         let (__ch, __next) = char_range_at(__input, __pos);
@@ -395,7 +395,7 @@ fn __parse_bin<'input>(__input: &'input str, __state: &mut ParseState<'input>, _
     }
 }
 
-fn __parse_constant<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Constant> {
+fn __parse_constant<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Constant> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -462,7 +462,7 @@ fn __parse_constant<'input>(__input: &'input str, __state: &mut ParseState<'inpu
     }
 }
 
-fn __parse_numeric_constant<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Constant> {
+fn __parse_numeric_constant<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Constant> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -485,7 +485,7 @@ fn __parse_numeric_constant<'input>(__input: &'input str, __state: &mut ParseSta
     }
 }
 
-fn __parse_integer_constant<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Integer> {
+fn __parse_integer_constant<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Integer> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = __parse_integer_number(__input, __state, __pos, env);
@@ -505,7 +505,7 @@ fn __parse_integer_constant<'input>(__input: &'input str, __state: &mut ParseSta
     }
 }
 
-fn __parse_integer_number<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<(IntegerBase, &'input str)> {
+fn __parse_integer_number<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<(IntegerBase, &'input str)> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -724,7 +724,7 @@ fn __parse_integer_number<'input>(__input: &'input str, __state: &mut ParseState
     }
 }
 
-fn __parse_integer_suffix<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<IntegerSuffix> {
+fn __parse_integer_suffix<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<IntegerSuffix> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -743,7 +743,7 @@ fn __parse_integer_suffix<'input>(__input: &'input str, __state: &mut ParseState
     }
 }
 
-fn __parse_integer_suffix_inner<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<IntegerSuffix> {
+fn __parse_integer_suffix_inner<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<IntegerSuffix> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -823,7 +823,7 @@ fn __parse_integer_suffix_inner<'input>(__input: &'input str, __state: &mut Pars
     }
 }
 
-fn __parse_float_constant<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Float> {
+fn __parse_float_constant<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Float> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = __parse_float_number(__input, __state, __pos, env);
@@ -843,7 +843,7 @@ fn __parse_float_constant<'input>(__input: &'input str, __state: &mut ParseState
     }
 }
 
-fn __parse_float_number<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<(FloatBase, &'input str)> {
+fn __parse_float_number<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<(FloatBase, &'input str)> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -884,7 +884,7 @@ fn __parse_float_number<'input>(__input: &'input str, __state: &mut ParseState<'
     }
 }
 
-fn __parse_float_decimal<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<()> {
+fn __parse_float_decimal<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<()> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -1021,7 +1021,7 @@ fn __parse_float_decimal<'input>(__input: &'input str, __state: &mut ParseState<
     }
 }
 
-fn __parse_float_decimal_exp<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<()> {
+fn __parse_float_decimal_exp<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<()> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = if __input.len() > __pos {
@@ -1078,7 +1078,7 @@ fn __parse_float_decimal_exp<'input>(__input: &'input str, __state: &mut ParseSt
     }
 }
 
-fn __parse_float_hexadecimal<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<()> {
+fn __parse_float_hexadecimal<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<()> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -1209,7 +1209,7 @@ fn __parse_float_hexadecimal<'input>(__input: &'input str, __state: &mut ParseSt
     }
 }
 
-fn __parse_float_binary_exp<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<()> {
+fn __parse_float_binary_exp<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<()> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = if __input.len() > __pos {
@@ -1266,7 +1266,7 @@ fn __parse_float_binary_exp<'input>(__input: &'input str, __state: &mut ParseSta
     }
 }
 
-fn __parse_float_suffix<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<FloatSuffix> {
+fn __parse_float_suffix<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<FloatSuffix> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -1285,7 +1285,7 @@ fn __parse_float_suffix<'input>(__input: &'input str, __state: &mut ParseState<'
     }
 }
 
-fn __parse_float_suffix_inner<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<FloatSuffix> {
+fn __parse_float_suffix_inner<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<FloatSuffix> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -1379,7 +1379,7 @@ fn __parse_float_suffix_inner<'input>(__input: &'input str, __state: &mut ParseS
     }
 }
 
-fn __parse_float_format<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<FloatFormat> {
+fn __parse_float_format<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<FloatFormat> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -1436,7 +1436,7 @@ fn __parse_float_format<'input>(__input: &'input str, __state: &mut ParseState<'
     }
 }
 
-fn __parse_character_constant<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<String> {
+fn __parse_character_constant<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<String> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -1503,7 +1503,7 @@ fn __parse_character_constant<'input>(__input: &'input str, __state: &mut ParseS
     }
 }
 
-fn __parse_character<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<()> {
+fn __parse_character<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<()> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = if __input.len() > __pos {
@@ -1522,7 +1522,7 @@ fn __parse_character<'input>(__input: &'input str, __state: &mut ParseState<'inp
     }
 }
 
-fn __parse_escape_sequence<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<()> {
+fn __parse_escape_sequence<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<()> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = slice_eq(__input, __state, __pos, "\\");
@@ -1604,7 +1604,7 @@ fn __parse_escape_sequence<'input>(__input: &'input str, __state: &mut ParseStat
     }
 }
 
-fn __parse_string_literal<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Node<Vec<String>>> {
+fn __parse_string_literal<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Node<Vec<String>>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -1669,7 +1669,7 @@ fn __parse_string_literal<'input>(__input: &'input str, __state: &mut ParseState
     }
 }
 
-fn __parse_string_literal0<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<String> {
+fn __parse_string_literal0<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<String> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -1722,7 +1722,7 @@ fn __parse_string_literal0<'input>(__input: &'input str, __state: &mut ParseStat
     }
 }
 
-fn __parse_encoding_prefix<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<()> {
+fn __parse_encoding_prefix<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<()> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = slice_eq(__input, __state, __pos, "u8");
@@ -1743,7 +1743,7 @@ fn __parse_encoding_prefix<'input>(__input: &'input str, __state: &mut ParseStat
     }
 }
 
-fn __parse_string_char<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<()> {
+fn __parse_string_char<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<()> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = if __input.len() > __pos {
@@ -1762,7 +1762,7 @@ fn __parse_string_char<'input>(__input: &'input str, __state: &mut ParseState<'i
     }
 }
 
-fn __parse_primary_expression<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Box<Node<Expression>>> {
+fn __parse_primary_expression<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Box<Node<Expression<T>>>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -1791,7 +1791,7 @@ fn __parse_primary_expression<'input>(__input: &'input str, __state: &mut ParseS
     }
 }
 
-fn __parse_primary_expression0<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Expression> {
+fn __parse_primary_expression0<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Expression<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -1936,7 +1936,7 @@ fn __parse_primary_expression0<'input>(__input: &'input str, __state: &mut Parse
     }
 }
 
-fn __parse_generic_selection<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<GenericSelection> {
+fn __parse_generic_selection<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<GenericSelection<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -2106,7 +2106,7 @@ fn __parse_generic_selection<'input>(__input: &'input str, __state: &mut ParseSt
     }
 }
 
-fn __parse_generic_association<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<GenericAssociation> {
+fn __parse_generic_association<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<GenericAssociation<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -2213,7 +2213,7 @@ fn __parse_generic_association<'input>(__input: &'input str, __state: &mut Parse
     }
 }
 
-fn __parse_postfix_expression<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Box<Node<Expression>>> {
+fn __parse_postfix_expression<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Box<Node<Expression<T>>>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -2242,7 +2242,7 @@ fn __parse_postfix_expression<'input>(__input: &'input str, __state: &mut ParseS
     }
 }
 
-fn __parse_postfix_expression0<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Expression> {
+fn __parse_postfix_expression0<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Expression<T>> {
     #![allow(non_snake_case, unused)]
     if let Some(entry) = __state.postfix_expression0_cache.get(&__pos) {
         return entry.clone();
@@ -2338,7 +2338,7 @@ fn __parse_postfix_expression0<'input>(__input: &'input str, __state: &mut Parse
     __rule_result
 }
 
-fn __parse_postfix_expression1<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Expression> {
+fn __parse_postfix_expression1<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Expression<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = __parse_compound_literal(__input, __state, __pos, env);
@@ -2349,7 +2349,7 @@ fn __parse_postfix_expression1<'input>(__input: &'input str, __state: &mut Parse
     }
 }
 
-fn __parse_postfix_expressionT<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Operation> {
+fn __parse_postfix_expressionT<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Operation<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = __parse_index_operator(__input, __state, __pos, env);
@@ -2524,7 +2524,7 @@ fn __parse_postfix_expressionT<'input>(__input: &'input str, __state: &mut Parse
     }
 }
 
-fn __parse_index_operator<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Operation> {
+fn __parse_index_operator<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Operation<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -2553,7 +2553,7 @@ fn __parse_index_operator<'input>(__input: &'input str, __state: &mut ParseState
     }
 }
 
-fn __parse_index_operator0<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Node<Expression>> {
+fn __parse_index_operator0<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Node<Expression<T>>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = slice_eq(__input, __state, __pos, "[");
@@ -2606,7 +2606,7 @@ fn __parse_index_operator0<'input>(__input: &'input str, __state: &mut ParseStat
     }
 }
 
-fn __parse_member_operator<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<MemberOperator> {
+fn __parse_member_operator<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<MemberOperator> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -2629,7 +2629,7 @@ fn __parse_member_operator<'input>(__input: &'input str, __state: &mut ParseStat
     }
 }
 
-fn __parse_postfix_operator<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<UnaryOperator> {
+fn __parse_postfix_operator<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<UnaryOperator> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -2652,7 +2652,7 @@ fn __parse_postfix_operator<'input>(__input: &'input str, __state: &mut ParseSta
     }
 }
 
-fn __parse_compound_literal<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Expression> {
+fn __parse_compound_literal<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Expression<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -2681,7 +2681,7 @@ fn __parse_compound_literal<'input>(__input: &'input str, __state: &mut ParseSta
     }
 }
 
-fn __parse_compound_literal_inner<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<CompoundLiteral> {
+fn __parse_compound_literal_inner<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<CompoundLiteral<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = slice_eq(__input, __state, __pos, "(");
@@ -2833,7 +2833,7 @@ fn __parse_compound_literal_inner<'input>(__input: &'input str, __state: &mut Pa
     }
 }
 
-fn __parse_unary_expression<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Box<Node<Expression>>> {
+fn __parse_unary_expression<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Box<Node<Expression<T>>>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -2862,7 +2862,7 @@ fn __parse_unary_expression<'input>(__input: &'input str, __state: &mut ParseSta
     }
 }
 
-fn __parse_unary_expression0<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Expression> {
+fn __parse_unary_expression0<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Expression<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = __parse_postfix_expression0(__input, __state, __pos, env);
@@ -2968,7 +2968,7 @@ fn __parse_unary_expression0<'input>(__input: &'input str, __state: &mut ParseSt
     }
 }
 
-fn __parse_unary_prefix<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Expression> {
+fn __parse_unary_prefix<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Expression<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -2997,7 +2997,7 @@ fn __parse_unary_prefix<'input>(__input: &'input str, __state: &mut ParseState<'
     }
 }
 
-fn __parse_unary_prefix_inner<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<UnaryOperatorExpression> {
+fn __parse_unary_prefix_inner<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<UnaryOperatorExpression<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -3038,7 +3038,7 @@ fn __parse_unary_prefix_inner<'input>(__input: &'input str, __state: &mut ParseS
     }
 }
 
-fn __parse_prefix_operator<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<UnaryOperator> {
+fn __parse_prefix_operator<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<UnaryOperator> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -3106,7 +3106,7 @@ fn __parse_prefix_operator<'input>(__input: &'input str, __state: &mut ParseStat
     }
 }
 
-fn __parse_unary_cast<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Expression> {
+fn __parse_unary_cast<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Expression<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -3135,7 +3135,7 @@ fn __parse_unary_cast<'input>(__input: &'input str, __state: &mut ParseState<'in
     }
 }
 
-fn __parse_unary_cast_inner<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<UnaryOperatorExpression> {
+fn __parse_unary_cast_inner<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<UnaryOperatorExpression<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -3176,7 +3176,7 @@ fn __parse_unary_cast_inner<'input>(__input: &'input str, __state: &mut ParseSta
     }
 }
 
-fn __parse_unary_operator<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<UnaryOperator> {
+fn __parse_unary_operator<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<UnaryOperator> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -3261,7 +3261,7 @@ fn __parse_unary_operator<'input>(__input: &'input str, __state: &mut ParseState
     }
 }
 
-fn __parse_sizeof_expression<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Expression> {
+fn __parse_sizeof_expression<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Expression<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -3341,7 +3341,7 @@ fn __parse_sizeof_expression<'input>(__input: &'input str, __state: &mut ParseSt
     }
 }
 
-fn __parse_alignof_expression<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Expression> {
+fn __parse_alignof_expression<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Expression<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -3456,7 +3456,7 @@ fn __parse_alignof_expression<'input>(__input: &'input str, __state: &mut ParseS
     }
 }
 
-fn __parse_cast_expression<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Box<Node<Expression>>> {
+fn __parse_cast_expression<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Box<Node<Expression<T>>>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -3485,7 +3485,7 @@ fn __parse_cast_expression<'input>(__input: &'input str, __state: &mut ParseStat
     }
 }
 
-fn __parse_cast_expression0<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Expression> {
+fn __parse_cast_expression0<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Expression<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -3520,7 +3520,7 @@ fn __parse_cast_expression0<'input>(__input: &'input str, __state: &mut ParseSta
     }
 }
 
-fn __parse_cast_expression_inner<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<CastExpression> {
+fn __parse_cast_expression_inner<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<CastExpression<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = slice_eq(__input, __state, __pos, "(");
@@ -3567,7 +3567,7 @@ fn __parse_cast_expression_inner<'input>(__input: &'input str, __state: &mut Par
     }
 }
 
-fn __parse_binary_expression<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Box<Node<Expression>>> {
+fn __parse_binary_expression<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Box<Node<Expression<T>>>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = __parse_binary_expression0(__input, __state, __pos, env);
@@ -3578,10 +3578,10 @@ fn __parse_binary_expression<'input>(__input: &'input str, __state: &mut ParseSt
     }
 }
 
-fn __parse_binary_expression0<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Node<Expression>> {
+fn __parse_binary_expression0<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Node<Expression<T>>> {
     #![allow(non_snake_case, unused)]
     {
-        fn __infix_parse<'input>(__min_prec: i32, __input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Node<Expression>> {
+        fn __infix_parse<'input, T: Name>(__min_prec: i32, __input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Node<Expression<T>>> {
             if let Matched(__pos, mut __infix_result) = __parse_binary_operand(__input, __state, __pos, env) {
                 let mut __repeat_pos = __pos;
                 loop {
@@ -4423,7 +4423,7 @@ fn __parse_binary_expression0<'input>(__input: &'input str, __state: &mut ParseS
     }
 }
 
-fn __parse_binary_operand<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Node<Expression>> {
+fn __parse_binary_operand<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Node<Expression<T>>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = Matched(__pos, __pos);
@@ -4446,7 +4446,7 @@ fn __parse_binary_operand<'input>(__input: &'input str, __state: &mut ParseState
     }
 }
 
-fn __parse_conditional_expression<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Box<Node<Expression>>> {
+fn __parse_conditional_expression<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Box<Node<Expression<T>>>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -4475,7 +4475,7 @@ fn __parse_conditional_expression<'input>(__input: &'input str, __state: &mut Pa
     }
 }
 
-fn __parse_conditional_expression0<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Expression> {
+fn __parse_conditional_expression0<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Expression<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = __parse_binary_expression0(__input, __state, __pos, env);
@@ -4508,7 +4508,7 @@ fn __parse_conditional_expression0<'input>(__input: &'input str, __state: &mut P
     }
 }
 
-fn __parse_conditional_expressionT<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<(Box<Node<Expression>>, Box<Node<Expression>>)> {
+fn __parse_conditional_expressionT<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<(Box<Node<Expression<T>>>, Box<Node<Expression<T>>>)> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = slice_eq(__input, __state, __pos, "?");
@@ -4591,7 +4591,7 @@ fn __parse_conditional_expressionT<'input>(__input: &'input str, __state: &mut P
     }
 }
 
-fn __parse_assignment_expression<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Box<Node<Expression>>> {
+fn __parse_assignment_expression<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Box<Node<Expression<T>>>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -4620,7 +4620,7 @@ fn __parse_assignment_expression<'input>(__input: &'input str, __state: &mut Par
     }
 }
 
-fn __parse_assignment_expression0<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Expression> {
+fn __parse_assignment_expression0<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Expression<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -4655,7 +4655,7 @@ fn __parse_assignment_expression0<'input>(__input: &'input str, __state: &mut Pa
     }
 }
 
-fn __parse_assignment_expression_inner<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<BinaryOperatorExpression> {
+fn __parse_assignment_expression_inner<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<BinaryOperatorExpression<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = __parse_unary_expression(__input, __state, __pos, env);
@@ -4708,7 +4708,7 @@ fn __parse_assignment_expression_inner<'input>(__input: &'input str, __state: &m
     }
 }
 
-fn __parse_assignment_operator<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<BinaryOperator> {
+fn __parse_assignment_operator<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<BinaryOperator> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -4839,7 +4839,7 @@ fn __parse_assignment_operator<'input>(__input: &'input str, __state: &mut Parse
     }
 }
 
-fn __parse_expression<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Box<Node<Expression>>> {
+fn __parse_expression<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Box<Node<Expression<T>>>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -4868,7 +4868,7 @@ fn __parse_expression<'input>(__input: &'input str, __state: &mut ParseState<'in
     }
 }
 
-fn __parse_expression0<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Expression> {
+fn __parse_expression0<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Expression<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -4949,7 +4949,7 @@ fn __parse_expression0<'input>(__input: &'input str, __state: &mut ParseState<'i
     }
 }
 
-fn __parse_expressionT<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Node<Expression>> {
+fn __parse_expressionT<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Node<Expression<T>>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = slice_eq(__input, __state, __pos, ",");
@@ -4990,17 +4990,17 @@ fn __parse_expressionT<'input>(__input: &'input str, __state: &mut ParseState<'i
     }
 }
 
-fn __parse_constant_expression<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Box<Node<Expression>>> {
+fn __parse_constant_expression<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Box<Node<Expression<T>>>> {
     #![allow(non_snake_case, unused)]
     __parse_conditional_expression(__input, __state, __pos, env)
 }
 
-fn __parse_constant_expression0<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Expression> {
+fn __parse_constant_expression0<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Expression<T>> {
     #![allow(non_snake_case, unused)]
     __parse_conditional_expression0(__input, __state, __pos, env)
 }
 
-fn __parse_declaration<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Node<Declaration>> {
+fn __parse_declaration<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Node<Declaration<T>>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = Matched(__pos, __pos);
@@ -5023,7 +5023,7 @@ fn __parse_declaration<'input>(__input: &'input str, __state: &mut ParseState<'i
     }
 }
 
-fn __parse_declaration0<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Declaration> {
+fn __parse_declaration0<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Declaration<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = match {
@@ -5114,7 +5114,7 @@ fn __parse_declaration0<'input>(__input: &'input str, __state: &mut ParseState<'
     }
 }
 
-fn __parse_declaration1<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<(Vec<Node<DeclarationSpecifier>>, Vec<Node<InitDeclarator>>)> {
+fn __parse_declaration1<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<(Vec<Node<DeclarationSpecifier<T>>>, Vec<Node<InitDeclarator<T>>>)> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = __parse_declaration_specifiers_unique(__input, __state, __pos, env);
@@ -5137,7 +5137,7 @@ fn __parse_declaration1<'input>(__input: &'input str, __state: &mut ParseState<'
     }
 }
 
-fn __parse_declaration2<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<(Vec<Node<DeclarationSpecifier>>, Vec<Node<InitDeclarator>>)> {
+fn __parse_declaration2<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<(Vec<Node<DeclarationSpecifier<T>>>, Vec<Node<InitDeclarator<T>>>)> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -5340,7 +5340,7 @@ fn __parse_declaration2<'input>(__input: &'input str, __state: &mut ParseState<'
     }
 }
 
-fn __parse_declaration_typedef_tail<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<(Vec<Node<DeclarationSpecifier>>, Vec<Node<InitDeclarator>>)> {
+fn __parse_declaration_typedef_tail<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<(Vec<Node<DeclarationSpecifier<T>>>, Vec<Node<InitDeclarator<T>>>)> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = __parse_declaration_specifiers_unique(__input, __state, __pos, env);
@@ -5363,7 +5363,7 @@ fn __parse_declaration_typedef_tail<'input>(__input: &'input str, __state: &mut 
     }
 }
 
-fn __parse_declaration_typedef_tail0<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<(Vec<Node<DeclarationSpecifier>>, Vec<Node<InitDeclarator>>)> {
+fn __parse_declaration_typedef_tail0<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<(Vec<Node<DeclarationSpecifier<T>>>, Vec<Node<InitDeclarator<T>>>)> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -5446,7 +5446,7 @@ fn __parse_declaration_typedef_tail0<'input>(__input: &'input str, __state: &mut
     }
 }
 
-fn __parse_declaration_unique_type<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Vec<Node<DeclarationSpecifier>>> {
+fn __parse_declaration_unique_type<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Vec<Node<DeclarationSpecifier<T>>>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -5475,7 +5475,7 @@ fn __parse_declaration_unique_type<'input>(__input: &'input str, __state: &mut P
     }
 }
 
-fn __parse_declaration_nonunique_type<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Vec<Node<DeclarationSpecifier>>> {
+fn __parse_declaration_nonunique_type<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Vec<Node<DeclarationSpecifier<T>>>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -5504,7 +5504,7 @@ fn __parse_declaration_nonunique_type<'input>(__input: &'input str, __state: &mu
     }
 }
 
-fn __parse_declaration_specifiers<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Vec<Node<DeclarationSpecifier>>> {
+fn __parse_declaration_specifiers<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Vec<Node<DeclarationSpecifier<T>>>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = __parse_declaration_specifiers_unique(__input, __state, __pos, env);
@@ -5527,7 +5527,7 @@ fn __parse_declaration_specifiers<'input>(__input: &'input str, __state: &mut Pa
     }
 }
 
-fn __parse_declaration_specifiers_tail<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Vec<Node<DeclarationSpecifier>>> {
+fn __parse_declaration_specifiers_tail<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Vec<Node<DeclarationSpecifier<T>>>> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -5574,7 +5574,7 @@ fn __parse_declaration_specifiers_tail<'input>(__input: &'input str, __state: &m
     }
 }
 
-fn __parse_declaration_specifiers_unique<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Vec<Node<DeclarationSpecifier>>> {
+fn __parse_declaration_specifiers_unique<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Vec<Node<DeclarationSpecifier<T>>>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -5629,7 +5629,7 @@ fn __parse_declaration_specifiers_unique<'input>(__input: &'input str, __state: 
     }
 }
 
-fn __parse_declaration_specifiers_nonunique<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Vec<Node<DeclarationSpecifier>>> {
+fn __parse_declaration_specifiers_nonunique<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Vec<Node<DeclarationSpecifier<T>>>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -5690,7 +5690,7 @@ fn __parse_declaration_specifiers_nonunique<'input>(__input: &'input str, __stat
     }
 }
 
-fn __parse_declaration_specifier_nontype<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<DeclarationSpecifier> {
+fn __parse_declaration_specifier_nontype<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<DeclarationSpecifier<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -5769,7 +5769,7 @@ fn __parse_declaration_specifier_nontype<'input>(__input: &'input str, __state: 
     }
 }
 
-fn __parse_declaration_typedef<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Vec<Node<DeclarationSpecifier>>> {
+fn __parse_declaration_typedef<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Vec<Node<DeclarationSpecifier<T>>>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -5798,7 +5798,7 @@ fn __parse_declaration_typedef<'input>(__input: &'input str, __state: &mut Parse
     }
 }
 
-fn __parse_declaration_typedef0<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<DeclarationSpecifier> {
+fn __parse_declaration_typedef0<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<DeclarationSpecifier<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = __parse_storage_class_typedef(__input, __state, __pos, env);
@@ -5809,7 +5809,7 @@ fn __parse_declaration_typedef0<'input>(__input: &'input str, __state: &mut Pars
     }
 }
 
-fn __parse_declaration_specifier_unique_type0<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<DeclarationSpecifier> {
+fn __parse_declaration_specifier_unique_type0<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<DeclarationSpecifier<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -5838,7 +5838,7 @@ fn __parse_declaration_specifier_unique_type0<'input>(__input: &'input str, __st
     }
 }
 
-fn __parse_declaration_specifier_nonunique_type0<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<DeclarationSpecifier> {
+fn __parse_declaration_specifier_nonunique_type0<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<DeclarationSpecifier<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -5867,7 +5867,7 @@ fn __parse_declaration_specifier_nonunique_type0<'input>(__input: &'input str, _
     }
 }
 
-fn __parse_declaration_init_declarators<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Vec<Node<InitDeclarator>>> {
+fn __parse_declaration_init_declarators<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Vec<Node<InitDeclarator<T>>>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -5934,7 +5934,7 @@ fn __parse_declaration_init_declarators<'input>(__input: &'input str, __state: &
     }
 }
 
-fn __parse_declaration_type_declarators<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Vec<Node<InitDeclarator>>> {
+fn __parse_declaration_type_declarators<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Vec<Node<InitDeclarator<T>>>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -6001,7 +6001,7 @@ fn __parse_declaration_type_declarators<'input>(__input: &'input str, __state: &
     }
 }
 
-fn __parse_init_declarator<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<InitDeclarator> {
+fn __parse_init_declarator<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<InitDeclarator<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = __parse_init_declarator_declarator(__input, __state, __pos, env);
@@ -6080,7 +6080,7 @@ fn __parse_init_declarator<'input>(__input: &'input str, __state: &mut ParseStat
     }
 }
 
-fn __parse_init_declarator_declarator<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Node<Declarator>> {
+fn __parse_init_declarator_declarator<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Node<Declarator<T>>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = __parse_declarator(__input, __state, __pos, env);
@@ -6094,7 +6094,7 @@ fn __parse_init_declarator_declarator<'input>(__input: &'input str, __state: &mu
     }
 }
 
-fn __parse_init_declarator_init<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Initializer> {
+fn __parse_init_declarator_init<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Initializer<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = slice_eq(__input, __state, __pos, "=");
@@ -6117,7 +6117,7 @@ fn __parse_init_declarator_init<'input>(__input: &'input str, __state: &mut Pars
     }
 }
 
-fn __parse_init_declarator_gnu<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Vec<Node<Extension>>> {
+fn __parse_init_declarator_gnu<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Vec<Node<Extension<T>>>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = match __parse_asm_label(__input, __state, __pos, env) {
@@ -6143,7 +6143,7 @@ fn __parse_init_declarator_gnu<'input>(__input: &'input str, __state: &mut Parse
     }
 }
 
-fn __parse_type_declarator<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<InitDeclarator> {
+fn __parse_type_declarator<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<InitDeclarator<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = __parse_declarator(__input, __state, __pos, env);
@@ -6192,7 +6192,7 @@ fn __parse_type_declarator<'input>(__input: &'input str, __state: &mut ParseStat
     }
 }
 
-fn __parse_storage_class_specifier<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Node<StorageClassSpecifier>> {
+fn __parse_storage_class_specifier<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Node<StorageClassSpecifier>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = Matched(__pos, __pos);
@@ -6215,7 +6215,7 @@ fn __parse_storage_class_specifier<'input>(__input: &'input str, __state: &mut P
     }
 }
 
-fn __parse_storage_class_specifier0<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<StorageClassSpecifier> {
+fn __parse_storage_class_specifier0<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<StorageClassSpecifier> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -6439,7 +6439,7 @@ fn __parse_storage_class_specifier0<'input>(__input: &'input str, __state: &mut 
     }
 }
 
-fn __parse_storage_class_typedef<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Node<StorageClassSpecifier>> {
+fn __parse_storage_class_typedef<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Node<StorageClassSpecifier>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = Matched(__pos, __pos);
@@ -6462,7 +6462,7 @@ fn __parse_storage_class_typedef<'input>(__input: &'input str, __state: &mut Par
     }
 }
 
-fn __parse_storage_class_typedef0<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<StorageClassSpecifier> {
+fn __parse_storage_class_typedef0<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<StorageClassSpecifier> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -6506,7 +6506,7 @@ fn __parse_storage_class_typedef0<'input>(__input: &'input str, __state: &mut Pa
     }
 }
 
-fn __parse_type_specifier_unique<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<TypeSpecifier> {
+fn __parse_type_specifier_unique<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<TypeSpecifier<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -6748,7 +6748,7 @@ fn __parse_type_specifier_unique<'input>(__input: &'input str, __state: &mut Par
     }
 }
 
-fn __parse_type_specifier_nonunique<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<TypeSpecifier> {
+fn __parse_type_specifier_nonunique<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<TypeSpecifier<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -7293,7 +7293,7 @@ fn __parse_type_specifier_nonunique<'input>(__input: &'input str, __state: &mut 
     }
 }
 
-fn __parse_struct_or_union_specifier<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<StructType> {
+fn __parse_struct_or_union_specifier<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<StructType<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -7391,7 +7391,7 @@ fn __parse_struct_or_union_specifier<'input>(__input: &'input str, __state: &mut
     }
 }
 
-fn __parse_struct_or_union_body<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Option<Vec<Node<StructDeclaration>>>> {
+fn __parse_struct_or_union_body<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Option<Vec<Node<StructDeclaration<T>>>>> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -7530,7 +7530,7 @@ fn __parse_struct_or_union_body<'input>(__input: &'input str, __state: &mut Pars
     }
 }
 
-fn __parse_struct_or_union<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<StructKind> {
+fn __parse_struct_or_union<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<StructKind> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -7619,7 +7619,7 @@ fn __parse_struct_or_union<'input>(__input: &'input str, __state: &mut ParseStat
     }
 }
 
-fn __parse_struct_declaration<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<StructDeclaration> {
+fn __parse_struct_declaration<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<StructDeclaration<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -7737,7 +7737,7 @@ fn __parse_struct_declaration<'input>(__input: &'input str, __state: &mut ParseS
     }
 }
 
-fn __parse_struct_field<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<StructField> {
+fn __parse_struct_field<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<StructField<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = __parse_specifier_qualifiers(__input, __state, __pos, env);
@@ -7834,7 +7834,7 @@ fn __parse_struct_field<'input>(__input: &'input str, __state: &mut ParseState<'
     }
 }
 
-fn __parse_specifier_qualifiers<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Vec<Node<SpecifierQualifier>>> {
+fn __parse_specifier_qualifiers<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Vec<Node<SpecifierQualifier<T>>>> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -8175,7 +8175,7 @@ fn __parse_specifier_qualifiers<'input>(__input: &'input str, __state: &mut Pars
     }
 }
 
-fn __parse_specifier_qualifier_unique_type0<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<SpecifierQualifier> {
+fn __parse_specifier_qualifier_unique_type0<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<SpecifierQualifier<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -8204,7 +8204,7 @@ fn __parse_specifier_qualifier_unique_type0<'input>(__input: &'input str, __stat
     }
 }
 
-fn __parse_specifier_qualifier_nonunique_type0<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<SpecifierQualifier> {
+fn __parse_specifier_qualifier_nonunique_type0<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<SpecifierQualifier<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -8233,7 +8233,7 @@ fn __parse_specifier_qualifier_nonunique_type0<'input>(__input: &'input str, __s
     }
 }
 
-fn __parse_specifier_qualifier_qualifier0<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<SpecifierQualifier> {
+fn __parse_specifier_qualifier_qualifier0<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<SpecifierQualifier<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = __parse_type_qualifier(__input, __state, __pos, env);
@@ -8244,7 +8244,7 @@ fn __parse_specifier_qualifier_qualifier0<'input>(__input: &'input str, __state:
     }
 }
 
-fn __parse_struct_declarator<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<StructDeclarator> {
+fn __parse_struct_declarator<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<StructDeclarator<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -8358,7 +8358,7 @@ fn __parse_struct_declarator<'input>(__input: &'input str, __state: &mut ParseSt
     }
 }
 
-fn __parse_enum_specifier<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<EnumType> {
+fn __parse_enum_specifier<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<EnumType<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -8591,7 +8591,7 @@ fn __parse_enum_specifier<'input>(__input: &'input str, __state: &mut ParseState
     }
 }
 
-fn __parse_enumerator<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Enumerator> {
+fn __parse_enumerator<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Enumerator<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = __parse_identifier(__input, __state, __pos, env);
@@ -8606,7 +8606,7 @@ fn __parse_enumerator<'input>(__input: &'input str, __state: &mut ParseState<'in
                         };
                         match __seq_res {
                             Matched(__pos, e) => Matched(__pos, {
-                                env.add_symbol(&i.node.name, Symbol::Identifier);
+                                env.add_interned_symbol(&i.node.name, Symbol::Identifier);
                                 Enumerator { identifier: i, expression: e }
                             }),
                             Failed => Failed,
@@ -8620,7 +8620,7 @@ fn __parse_enumerator<'input>(__input: &'input str, __state: &mut ParseState<'in
     }
 }
 
-fn __parse_enumerator_constant<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Box<Node<Expression>>> {
+fn __parse_enumerator_constant<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Box<Node<Expression<T>>>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = slice_eq(__input, __state, __pos, "=");
@@ -8643,7 +8643,7 @@ fn __parse_enumerator_constant<'input>(__input: &'input str, __state: &mut Parse
     }
 }
 
-fn __parse_type_qualifier<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Node<TypeQualifier>> {
+fn __parse_type_qualifier<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Node<TypeQualifier>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = Matched(__pos, __pos);
@@ -8666,7 +8666,7 @@ fn __parse_type_qualifier<'input>(__input: &'input str, __state: &mut ParseState
     }
 }
 
-fn __parse_type_qualifier0<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<TypeQualifier> {
+fn __parse_type_qualifier0<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<TypeQualifier> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -9156,7 +9156,7 @@ fn __parse_type_qualifier0<'input>(__input: &'input str, __state: &mut ParseStat
     }
 }
 
-fn __parse_function_specifier<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Node<FunctionSpecifier>> {
+fn __parse_function_specifier<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Node<FunctionSpecifier>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = Matched(__pos, __pos);
@@ -9179,7 +9179,7 @@ fn __parse_function_specifier<'input>(__input: &'input str, __state: &mut ParseS
     }
 }
 
-fn __parse_function_specifier0<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<FunctionSpecifier> {
+fn __parse_function_specifier0<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<FunctionSpecifier> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -9303,7 +9303,7 @@ fn __parse_function_specifier0<'input>(__input: &'input str, __state: &mut Parse
     }
 }
 
-fn __parse_alignment_specifier<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Node<AlignmentSpecifier>> {
+fn __parse_alignment_specifier<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Node<AlignmentSpecifier<T>>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = Matched(__pos, __pos);
@@ -9326,7 +9326,7 @@ fn __parse_alignment_specifier<'input>(__input: &'input str, __state: &mut Parse
     }
 }
 
-fn __parse_alignment_specifier0<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<AlignmentSpecifier> {
+fn __parse_alignment_specifier0<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<AlignmentSpecifier<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -9487,7 +9487,7 @@ fn __parse_alignment_specifier0<'input>(__input: &'input str, __state: &mut Pars
     }
 }
 
-fn __parse_declarator<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Node<Declarator>> {
+fn __parse_declarator<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Node<Declarator<T>>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = Matched(__pos, __pos);
@@ -9510,7 +9510,7 @@ fn __parse_declarator<'input>(__input: &'input str, __state: &mut ParseState<'in
     }
 }
 
-fn __parse_declarator0<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Declarator> {
+fn __parse_declarator0<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Declarator<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = match {
@@ -9674,7 +9674,7 @@ fn __parse_declarator0<'input>(__input: &'input str, __state: &mut ParseState<'i
     }
 }
 
-fn __parse_direct_declarator<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<DeclaratorKind> {
+fn __parse_direct_declarator<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<DeclaratorKind<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -9721,7 +9721,7 @@ fn __parse_direct_declarator<'input>(__input: &'input str, __state: &mut ParseSt
     }
 }
 
-fn __parse_derived_declarator<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<DerivedDeclarator> {
+fn __parse_derived_declarator<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<DerivedDeclarator<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -9924,7 +9924,7 @@ fn __parse_derived_declarator<'input>(__input: &'input str, __state: &mut ParseS
     }
 }
 
-fn __parse_array_declarator<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<ArrayDeclarator> {
+fn __parse_array_declarator<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<ArrayDeclarator<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -10345,7 +10345,7 @@ fn __parse_array_declarator<'input>(__input: &'input str, __state: &mut ParseSta
     }
 }
 
-fn __parse_function_declarator<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<FunctionDeclarator> {
+fn __parse_function_declarator<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<FunctionDeclarator<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -10416,7 +10416,7 @@ fn __parse_function_declarator<'input>(__input: &'input str, __state: &mut Parse
     }
 }
 
-fn __parse_pointer<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Node<DerivedDeclarator>> {
+fn __parse_pointer<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Node<DerivedDeclarator<T>>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = Matched(__pos, __pos);
@@ -10439,7 +10439,7 @@ fn __parse_pointer<'input>(__input: &'input str, __state: &mut ParseState<'input
     }
 }
 
-fn __parse_pointer0<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<DerivedDeclarator> {
+fn __parse_pointer0<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<DerivedDeclarator<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = slice_eq(__input, __state, __pos, "*");
@@ -10512,7 +10512,7 @@ fn __parse_pointer0<'input>(__input: &'input str, __state: &mut ParseState<'inpu
     }
 }
 
-fn __parse_pointer_qualifier<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<PointerQualifier> {
+fn __parse_pointer_qualifier<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<PointerQualifier<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -10555,7 +10555,7 @@ fn __parse_pointer_qualifier<'input>(__input: &'input str, __state: &mut ParseSt
     }
 }
 
-fn __parse_ellipsis<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Ellipsis> {
+fn __parse_ellipsis<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Ellipsis> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -10584,7 +10584,7 @@ fn __parse_ellipsis<'input>(__input: &'input str, __state: &mut ParseState<'inpu
     }
 }
 
-fn __parse_parameter_declaration<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Node<ParameterDeclaration>> {
+fn __parse_parameter_declaration<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Node<ParameterDeclaration<T>>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = Matched(__pos, __pos);
@@ -10607,7 +10607,7 @@ fn __parse_parameter_declaration<'input>(__input: &'input str, __state: &mut Par
     }
 }
 
-fn __parse_parameter_declaration0<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<ParameterDeclaration> {
+fn __parse_parameter_declaration0<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<ParameterDeclaration<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = __parse_declaration_specifiers(__input, __state, __pos, env);
@@ -10665,7 +10665,7 @@ fn __parse_parameter_declaration0<'input>(__input: &'input str, __state: &mut Pa
     }
 }
 
-fn __parse_parameter_declarator<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Option<Node<Declarator>>> {
+fn __parse_parameter_declarator<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Option<Node<Declarator<T>>>> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -10697,7 +10697,7 @@ fn __parse_parameter_declarator<'input>(__input: &'input str, __state: &mut Pars
     }
 }
 
-fn __parse_type_name<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Node<TypeName>> {
+fn __parse_type_name<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Node<TypeName<T>>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = Matched(__pos, __pos);
@@ -10720,7 +10720,7 @@ fn __parse_type_name<'input>(__input: &'input str, __state: &mut ParseState<'inp
     }
 }
 
-fn __parse_type_name0<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<TypeName> {
+fn __parse_type_name0<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<TypeName<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = __parse_specifier_qualifiers(__input, __state, __pos, env);
@@ -10746,7 +10746,7 @@ fn __parse_type_name0<'input>(__input: &'input str, __state: &mut ParseState<'in
     }
 }
 
-fn __parse_abstract_declarator<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Node<Declarator>> {
+fn __parse_abstract_declarator<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Node<Declarator<T>>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = Matched(__pos, __pos);
@@ -10769,7 +10769,7 @@ fn __parse_abstract_declarator<'input>(__input: &'input str, __state: &mut Parse
     }
 }
 
-fn __parse_abstract_declarator0<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Declarator> {
+fn __parse_abstract_declarator0<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Declarator<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -11038,7 +11038,7 @@ fn __parse_abstract_declarator0<'input>(__input: &'input str, __state: &mut Pars
     }
 }
 
-fn __parse_direct_abstract_declarator<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<DeclaratorKind> {
+fn __parse_direct_abstract_declarator<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<DeclaratorKind<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = slice_eq(__input, __state, __pos, "(");
@@ -11073,7 +11073,7 @@ fn __parse_direct_abstract_declarator<'input>(__input: &'input str, __state: &mu
     }
 }
 
-fn __parse_derived_abstract_declarator<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Node<DerivedDeclarator>> {
+fn __parse_derived_abstract_declarator<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Node<DerivedDeclarator<T>>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = Matched(__pos, __pos);
@@ -11096,7 +11096,7 @@ fn __parse_derived_abstract_declarator<'input>(__input: &'input str, __state: &m
     }
 }
 
-fn __parse_derived_abstract_declarator0<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<DerivedDeclarator> {
+fn __parse_derived_abstract_declarator0<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<DerivedDeclarator<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -11191,7 +11191,7 @@ fn __parse_derived_abstract_declarator0<'input>(__input: &'input str, __state: &
     }
 }
 
-fn __parse_abstract_array_declarator<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<ArrayDeclarator> {
+fn __parse_abstract_array_declarator<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<ArrayDeclarator<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -11568,7 +11568,7 @@ fn __parse_abstract_array_declarator<'input>(__input: &'input str, __state: &mut
     }
 }
 
-fn __parse_abstract_function_declarator<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<FunctionDeclarator> {
+fn __parse_abstract_function_declarator<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<FunctionDeclarator<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -11645,7 +11645,7 @@ fn __parse_abstract_function_declarator<'input>(__input: &'input str, __state: &
     }
 }
 
-fn __parse_typedef_name<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Node<Identifier>> {
+fn __parse_typedef_name<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Node<Identifier<T>>> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -11664,7 +11664,7 @@ fn __parse_typedef_name<'input>(__input: &'input str, __state: &mut ParseState<'
     }
 }
 
-fn __parse_typedef_name0<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Node<Identifier>> {
+fn __parse_typedef_name0<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Node<Identifier<T>>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = __parse_identifier(__input, __state, __pos, env);
@@ -11689,7 +11689,7 @@ fn __parse_typedef_name0<'input>(__input: &'input str, __state: &mut ParseState<
     }
 }
 
-fn __parse_initializer<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Initializer> {
+fn __parse_initializer<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Initializer<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -11861,7 +11861,7 @@ fn __parse_initializer<'input>(__input: &'input str, __state: &mut ParseState<'i
     }
 }
 
-fn __parse_initializer_list_item<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<InitializerListItem> {
+fn __parse_initializer_list_item<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<InitializerListItem<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = match __parse_designation(__input, __state, __pos, env) {
@@ -11905,7 +11905,7 @@ fn __parse_initializer_list_item<'input>(__input: &'input str, __state: &mut Par
     }
 }
 
-fn __parse_designation<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Vec<Node<Designator>>> {
+fn __parse_designation<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Vec<Node<Designator<T>>>> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -12082,7 +12082,7 @@ fn __parse_designation<'input>(__input: &'input str, __state: &mut ParseState<'i
     }
 }
 
-fn __parse_colon_designation<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Designator> {
+fn __parse_colon_designation<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Designator<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = __parse_identifier(__input, __state, __pos, env);
@@ -12105,7 +12105,7 @@ fn __parse_colon_designation<'input>(__input: &'input str, __state: &mut ParseSt
     }
 }
 
-fn __parse_designator<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Designator> {
+fn __parse_designator<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Designator<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -12140,7 +12140,7 @@ fn __parse_designator<'input>(__input: &'input str, __state: &mut ParseState<'in
     }
 }
 
-fn __parse_array_designator<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Designator> {
+fn __parse_array_designator<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Designator<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = slice_eq(__input, __state, __pos, "[");
@@ -12230,7 +12230,7 @@ fn __parse_array_designator<'input>(__input: &'input str, __state: &mut ParseSta
     }
 }
 
-fn __parse_range_designator_ext<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Node<Expression>> {
+fn __parse_range_designator_ext<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Node<Expression<T>>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = slice_eq(__input, __state, __pos, "...");
@@ -12271,7 +12271,7 @@ fn __parse_range_designator_ext<'input>(__input: &'input str, __state: &mut Pars
     }
 }
 
-fn __parse_static_assert<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Node<StaticAssert>> {
+fn __parse_static_assert<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Node<StaticAssert<T>>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = Matched(__pos, __pos);
@@ -12294,7 +12294,7 @@ fn __parse_static_assert<'input>(__input: &'input str, __state: &mut ParseState<
     }
 }
 
-fn __parse_static_assert0<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<StaticAssert> {
+fn __parse_static_assert0<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<StaticAssert<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = match {
@@ -12478,7 +12478,7 @@ fn __parse_static_assert0<'input>(__input: &'input str, __state: &mut ParseState
     }
 }
 
-fn __parse_statement<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Box<Node<Statement>>> {
+fn __parse_statement<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Box<Node<Statement<T>>>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -12507,7 +12507,7 @@ fn __parse_statement<'input>(__input: &'input str, __state: &mut ParseState<'inp
     }
 }
 
-fn __parse_statement0<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Statement> {
+fn __parse_statement0<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Statement<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -12676,7 +12676,7 @@ fn __parse_statement0<'input>(__input: &'input str, __state: &mut ParseState<'in
     }
 }
 
-fn __parse_labeled_statement<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<LabeledStatement> {
+fn __parse_labeled_statement<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<LabeledStatement<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -12729,7 +12729,7 @@ fn __parse_labeled_statement<'input>(__input: &'input str, __state: &mut ParseSt
     }
 }
 
-fn __parse_label<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Label> {
+fn __parse_label<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Label<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -12842,7 +12842,7 @@ fn __parse_label<'input>(__input: &'input str, __state: &mut ParseState<'input>,
     }
 }
 
-fn __parse_compound_statement<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Statement> {
+fn __parse_compound_statement<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Statement<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = slice_eq(__input, __state, __pos, "{");
@@ -12927,7 +12927,7 @@ fn __parse_compound_statement<'input>(__input: &'input str, __state: &mut ParseS
     }
 }
 
-fn __parse_block_item<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<BlockItem> {
+fn __parse_block_item<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<BlockItem<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -12980,7 +12980,7 @@ fn __parse_block_item<'input>(__input: &'input str, __state: &mut ParseState<'in
     }
 }
 
-fn __parse_expression_statement<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Statement> {
+fn __parse_expression_statement<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Statement<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = match __parse_expression(__input, __state, __pos, env) {
@@ -13006,7 +13006,7 @@ fn __parse_expression_statement<'input>(__input: &'input str, __state: &mut Pars
     }
 }
 
-fn __parse_selection_statement<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Statement> {
+fn __parse_selection_statement<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Statement<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -13065,7 +13065,7 @@ fn __parse_selection_statement<'input>(__input: &'input str, __state: &mut Parse
     }
 }
 
-fn __parse_if_statement<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<IfStatement> {
+fn __parse_if_statement<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<IfStatement<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -13172,7 +13172,7 @@ fn __parse_if_statement<'input>(__input: &'input str, __state: &mut ParseState<'
     }
 }
 
-fn __parse_else_statement<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Box<Node<Statement>>> {
+fn __parse_else_statement<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Box<Node<Statement<T>>>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -13228,7 +13228,7 @@ fn __parse_else_statement<'input>(__input: &'input str, __state: &mut ParseState
     }
 }
 
-fn __parse_switch_statement<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<SwitchStatement> {
+fn __parse_switch_statement<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<SwitchStatement<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -13320,7 +13320,7 @@ fn __parse_switch_statement<'input>(__input: &'input str, __state: &mut ParseSta
     }
 }
 
-fn __parse_iteration_statement<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Statement> {
+fn __parse_iteration_statement<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Statement<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -13409,7 +13409,7 @@ fn __parse_iteration_statement<'input>(__input: &'input str, __state: &mut Parse
     }
 }
 
-fn __parse_while_statement<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<WhileStatement> {
+fn __parse_while_statement<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<WhileStatement<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -13501,7 +13501,7 @@ fn __parse_while_statement<'input>(__input: &'input str, __state: &mut ParseStat
     }
 }
 
-fn __parse_do_while_statement<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<DoWhileStatement> {
+fn __parse_do_while_statement<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<DoWhileStatement<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -13650,7 +13650,7 @@ fn __parse_do_while_statement<'input>(__input: &'input str, __state: &mut ParseS
     }
 }
 
-fn __parse_for_statement<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<ForStatement> {
+fn __parse_for_statement<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<ForStatement<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -13802,7 +13802,7 @@ fn __parse_for_statement<'input>(__input: &'input str, __state: &mut ParseState<
     }
 }
 
-fn __parse_for_initializer<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<ForInitializer> {
+fn __parse_for_initializer<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<ForInitializer<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -13861,7 +13861,7 @@ fn __parse_for_initializer<'input>(__input: &'input str, __state: &mut ParseStat
     }
 }
 
-fn __parse_jump_statement<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Statement> {
+fn __parse_jump_statement<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Statement<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -14115,7 +14115,7 @@ fn __parse_jump_statement<'input>(__input: &'input str, __state: &mut ParseState
     }
 }
 
-fn __parse_translation_unit<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<TranslationUnit> {
+fn __parse_translation_unit<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<TranslationUnit<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = match __parse_directive(__input, __state, __pos, env) {
@@ -14197,7 +14197,7 @@ fn __parse_translation_unit<'input>(__input: &'input str, __state: &mut ParseSta
     }
 }
 
-fn __parse_external_declaration<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<ExternalDeclaration> {
+fn __parse_external_declaration<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<ExternalDeclaration<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -14278,7 +14278,7 @@ fn __parse_external_declaration<'input>(__input: &'input str, __state: &mut Pars
     }
 }
 
-fn __parse_function_definition<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<FunctionDefinition> {
+fn __parse_function_definition<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<FunctionDefinition<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = match {
@@ -14443,7 +14443,7 @@ fn __parse_function_definition<'input>(__input: &'input str, __state: &mut Parse
     }
 }
 
-fn __parse_gnu_guard<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<()> {
+fn __parse_gnu_guard<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<()> {
     #![allow(non_snake_case, unused)]
     match {
         if env.extensions_gnu {
@@ -14460,7 +14460,7 @@ fn __parse_gnu_guard<'input>(__input: &'input str, __state: &mut ParseState<'inp
     }
 }
 
-fn __parse_attribute_specifier_list<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Vec<Node<Extension>>> {
+fn __parse_attribute_specifier_list<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Vec<Node<Extension<T>>>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -14503,7 +14503,7 @@ fn __parse_attribute_specifier_list<'input>(__input: &'input str, __state: &mut 
     }
 }
 
-fn __parse_attribute_specifier<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Vec<Node<Extension>>> {
+fn __parse_attribute_specifier<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Vec<Node<Extension<T>>>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -14645,7 +14645,7 @@ fn __parse_attribute_specifier<'input>(__input: &'input str, __state: &mut Parse
     }
 }
 
-fn __parse_attribute<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Extension> {
+fn __parse_attribute<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Extension<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -14739,7 +14739,7 @@ fn __parse_attribute<'input>(__input: &'input str, __state: &mut ParseState<'inp
     }
 }
 
-fn __parse_attribute_name<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<String> {
+fn __parse_attribute_name<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<String> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -14798,7 +14798,7 @@ fn __parse_attribute_name<'input>(__input: &'input str, __state: &mut ParseState
     }
 }
 
-fn __parse_attribute_parameters<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Vec<Node<Expression>>> {
+fn __parse_attribute_parameters<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Vec<Node<Expression<T>>>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = slice_eq(__input, __state, __pos, "(");
@@ -14895,7 +14895,7 @@ fn __parse_attribute_parameters<'input>(__input: &'input str, __state: &mut Pars
     }
 }
 
-fn __parse_attr_availability<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<AvailabilityAttribute> {
+fn __parse_attr_availability<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<AvailabilityAttribute<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -15065,7 +15065,7 @@ fn __parse_attr_availability<'input>(__input: &'input str, __state: &mut ParseSt
     }
 }
 
-fn __parse_attr_availability_clause<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<AvailabilityClause> {
+fn __parse_attr_availability_clause<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<AvailabilityClause> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -15508,7 +15508,7 @@ fn __parse_attr_availability_clause<'input>(__input: &'input str, __state: &mut 
     }
 }
 
-fn __parse_attr_availability_version<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<AvailabilityVersion> {
+fn __parse_attr_availability_version<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<AvailabilityVersion> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -15630,7 +15630,7 @@ fn __parse_attr_availability_version<'input>(__input: &'input str, __state: &mut
     }
 }
 
-fn __parse_asm_label<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Node<Extension>> {
+fn __parse_asm_label<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Node<Extension<T>>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = Matched(__pos, __pos);
@@ -15653,7 +15653,7 @@ fn __parse_asm_label<'input>(__input: &'input str, __state: &mut ParseState<'inp
     }
 }
 
-fn __parse_asm_label0<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Extension> {
+fn __parse_asm_label0<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Extension<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = __parse_asm_label_keyword(__input, __state, __pos, env);
@@ -15700,7 +15700,7 @@ fn __parse_asm_label0<'input>(__input: &'input str, __state: &mut ParseState<'in
     }
 }
 
-fn __parse_asm_label_keyword<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<()> {
+fn __parse_asm_label_keyword<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<()> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -15800,7 +15800,7 @@ fn __parse_asm_label_keyword<'input>(__input: &'input str, __state: &mut ParseSt
     }
 }
 
-fn __parse_asm_statement<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Statement> {
+fn __parse_asm_statement<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Statement<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -15829,7 +15829,7 @@ fn __parse_asm_statement<'input>(__input: &'input str, __state: &mut ParseState<
     }
 }
 
-fn __parse_asm_statement0<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<AsmStatement> {
+fn __parse_asm_statement0<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<AsmStatement<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -16115,7 +16115,7 @@ fn __parse_asm_statement0<'input>(__input: &'input str, __state: &mut ParseState
     }
 }
 
-fn __parse_asm_operand_list<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Vec<Node<GnuAsmOperand>>> {
+fn __parse_asm_operand_list<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Vec<Node<GnuAsmOperand<T>>>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -16182,7 +16182,7 @@ fn __parse_asm_operand_list<'input>(__input: &'input str, __state: &mut ParseSta
     }
 }
 
-fn __parse_asm_operand<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<GnuAsmOperand> {
+fn __parse_asm_operand<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<GnuAsmOperand<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = match {
@@ -16292,7 +16292,7 @@ fn __parse_asm_operand<'input>(__input: &'input str, __state: &mut ParseState<'i
     }
 }
 
-fn __parse_gnu_primary_expression<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Expression> {
+fn __parse_gnu_primary_expression<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Expression<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = __parse_statement_expression(__input, __state, __pos, env);
@@ -16315,7 +16315,7 @@ fn __parse_gnu_primary_expression<'input>(__input: &'input str, __state: &mut Pa
     }
 }
 
-fn __parse_statement_expression<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Expression> {
+fn __parse_statement_expression<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Expression<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = slice_eq(__input, __state, __pos, "(");
@@ -16396,7 +16396,7 @@ fn __parse_statement_expression<'input>(__input: &'input str, __state: &mut Pars
     }
 }
 
-fn __parse_va_arg_expression<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Expression> {
+fn __parse_va_arg_expression<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Expression<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -16425,7 +16425,7 @@ fn __parse_va_arg_expression<'input>(__input: &'input str, __state: &mut ParseSt
     }
 }
 
-fn __parse_va_arg_expression_inner<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<VaArgExpression> {
+fn __parse_va_arg_expression_inner<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<VaArgExpression<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -16529,7 +16529,7 @@ fn __parse_va_arg_expression_inner<'input>(__input: &'input str, __state: &mut P
     }
 }
 
-fn __parse_keyword_expression<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Expression> {
+fn __parse_keyword_expression<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Expression<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -16559,7 +16559,7 @@ fn __parse_keyword_expression<'input>(__input: &'input str, __state: &mut ParseS
         };
         match __seq_res {
             Matched(__pos, k) => Matched(__pos, {
-                let ident = Identifier { name: k.node.to_string() };
+                let ident = Identifier { name: T::get_from_str(k.node) };
                 Expression::Identifier(Box::new(Node::new(ident, k.span)))
             }),
             Failed => Failed,
@@ -16567,7 +16567,7 @@ fn __parse_keyword_expression<'input>(__input: &'input str, __state: &mut ParseS
     }
 }
 
-fn __parse_keyword_expression0<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<()> {
+fn __parse_keyword_expression0<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<()> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -16683,7 +16683,7 @@ fn __parse_keyword_expression0<'input>(__input: &'input str, __state: &mut Parse
     }
 }
 
-fn __parse_offsetof_expression<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<Expression> {
+fn __parse_offsetof_expression<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<Expression<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -16712,7 +16712,7 @@ fn __parse_offsetof_expression<'input>(__input: &'input str, __state: &mut Parse
     }
 }
 
-fn __parse_offsetof_expression_inner<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<OffsetOfExpression> {
+fn __parse_offsetof_expression_inner<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<OffsetOfExpression<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -16834,7 +16834,7 @@ fn __parse_offsetof_expression_inner<'input>(__input: &'input str, __state: &mut
     }
 }
 
-fn __parse_offsetof_designator<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<OffsetDesignator> {
+fn __parse_offsetof_designator<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<OffsetDesignator<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = __parse_identifier(__input, __state, __pos, env);
@@ -16907,7 +16907,7 @@ fn __parse_offsetof_designator<'input>(__input: &'input str, __state: &mut Parse
     }
 }
 
-fn __parse_offsetof_member<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<OffsetMember> {
+fn __parse_offsetof_member<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<OffsetMember<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -17008,7 +17008,7 @@ fn __parse_offsetof_member<'input>(__input: &'input str, __state: &mut ParseStat
     }
 }
 
-fn __parse_typeof_specifier<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<TypeSpecifier> {
+fn __parse_typeof_specifier<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<TypeSpecifier<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -17121,7 +17121,7 @@ fn __parse_typeof_specifier<'input>(__input: &'input str, __state: &mut ParseSta
     }
 }
 
-fn __parse_typeof_specifier0<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<TypeOf> {
+fn __parse_typeof_specifier0<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<TypeOf<T>> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -17162,7 +17162,7 @@ fn __parse_typeof_specifier0<'input>(__input: &'input str, __state: &mut ParseSt
     }
 }
 
-fn __parse_ts18661_float_type_specifier<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<TS18661FloatType> {
+fn __parse_ts18661_float_type_specifier<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<TS18661FloatType> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = __parse_ts18661_binary_float(__input, __state, __pos, env);
@@ -17173,7 +17173,7 @@ fn __parse_ts18661_float_type_specifier<'input>(__input: &'input str, __state: &
     }
 }
 
-fn __parse_ts18661_binary_float<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<TS18661FloatType> {
+fn __parse_ts18661_binary_float<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<TS18661FloatType> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = slice_eq(__input, __state, __pos, "_Float");
@@ -17199,7 +17199,7 @@ fn __parse_ts18661_binary_float<'input>(__input: &'input str, __state: &mut Pars
     }
 }
 
-fn __parse_ts18661_binary_width<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<usize> {
+fn __parse_ts18661_binary_width<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<usize> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -17234,7 +17234,7 @@ fn __parse_ts18661_binary_width<'input>(__input: &'input str, __state: &mut Pars
     }
 }
 
-fn __parse_ts18661_decimal_float<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<TS18661FloatType> {
+fn __parse_ts18661_decimal_float<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<TS18661FloatType> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = slice_eq(__input, __state, __pos, "_Decimal");
@@ -17260,7 +17260,7 @@ fn __parse_ts18661_decimal_float<'input>(__input: &'input str, __state: &mut Par
     }
 }
 
-fn __parse_ts18661_decimal_width<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<usize> {
+fn __parse_ts18661_decimal_width<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<usize> {
     #![allow(non_snake_case, unused)]
     {
         let __seq_res = {
@@ -17289,7 +17289,7 @@ fn __parse_ts18661_decimal_width<'input>(__input: &'input str, __state: &mut Par
     }
 }
 
-fn __parse_ts18661_float_suffix<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<TS18661FloatType> {
+fn __parse_ts18661_float_suffix<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<TS18661FloatType> {
     #![allow(non_snake_case, unused)]
     {
         let __choice_res = {
@@ -17412,7 +17412,7 @@ fn __parse_ts18661_float_suffix<'input>(__input: &'input str, __state: &mut Pars
     }
 }
 
-fn __parse_clang_guard<'input>(__input: &'input str, __state: &mut ParseState<'input>, __pos: usize, env: &mut Env) -> RuleResult<()> {
+fn __parse_clang_guard<'input, T: Name>(__input: &'input str, __state: &mut ParseState<'input, T>, __pos: usize, env: &mut Env<T>) -> RuleResult<()> {
     #![allow(non_snake_case, unused)]
     match {
         if env.extensions_clang {
@@ -17429,7 +17429,7 @@ fn __parse_clang_guard<'input>(__input: &'input str, __state: &mut ParseState<'i
     }
 }
 
-pub fn constant<'input>(__input: &'input str, env: &mut Env) -> ParseResult<Constant> {
+pub fn constant<'input, T: Name>(__input: &'input str, env: &mut Env<T>) -> ParseResult<Constant> {
     #![allow(non_snake_case, unused)]
     let mut __state = ParseState::new();
     match __parse_constant(__input, &mut __state, 0, env) {
@@ -17444,7 +17444,7 @@ pub fn constant<'input>(__input: &'input str, env: &mut Env) -> ParseResult<Cons
     Err(ParseError { line: __line, column: __col, offset: __state.max_err_pos, expected: __state.expected })
 }
 
-pub fn string_literal<'input>(__input: &'input str, env: &mut Env) -> ParseResult<Node<Vec<String>>> {
+pub fn string_literal<'input, T: Name>(__input: &'input str, env: &mut Env<T>) -> ParseResult<Node<Vec<String>>> {
     #![allow(non_snake_case, unused)]
     let mut __state = ParseState::new();
     match __parse_string_literal(__input, &mut __state, 0, env) {
@@ -17459,7 +17459,7 @@ pub fn string_literal<'input>(__input: &'input str, env: &mut Env) -> ParseResul
     Err(ParseError { line: __line, column: __col, offset: __state.max_err_pos, expected: __state.expected })
 }
 
-pub fn expression<'input>(__input: &'input str, env: &mut Env) -> ParseResult<Box<Node<Expression>>> {
+pub fn expression<'input, T: Name>(__input: &'input str, env: &mut Env<T>) -> ParseResult<Box<Node<Expression<T>>>> {
     #![allow(non_snake_case, unused)]
     let mut __state = ParseState::new();
     match __parse_expression(__input, &mut __state, 0, env) {
@@ -17474,7 +17474,7 @@ pub fn expression<'input>(__input: &'input str, env: &mut Env) -> ParseResult<Bo
     Err(ParseError { line: __line, column: __col, offset: __state.max_err_pos, expected: __state.expected })
 }
 
-pub fn declaration<'input>(__input: &'input str, env: &mut Env) -> ParseResult<Node<Declaration>> {
+pub fn declaration<'input, T: Name>(__input: &'input str, env: &mut Env<T>) -> ParseResult<Node<Declaration<T>>> {
     #![allow(non_snake_case, unused)]
     let mut __state = ParseState::new();
     match __parse_declaration(__input, &mut __state, 0, env) {
@@ -17489,7 +17489,7 @@ pub fn declaration<'input>(__input: &'input str, env: &mut Env) -> ParseResult<N
     Err(ParseError { line: __line, column: __col, offset: __state.max_err_pos, expected: __state.expected })
 }
 
-pub fn statement<'input>(__input: &'input str, env: &mut Env) -> ParseResult<Box<Node<Statement>>> {
+pub fn statement<'input, T: Name>(__input: &'input str, env: &mut Env<T>) -> ParseResult<Box<Node<Statement<T>>>> {
     #![allow(non_snake_case, unused)]
     let mut __state = ParseState::new();
     match __parse_statement(__input, &mut __state, 0, env) {
@@ -17504,7 +17504,7 @@ pub fn statement<'input>(__input: &'input str, env: &mut Env) -> ParseResult<Box
     Err(ParseError { line: __line, column: __col, offset: __state.max_err_pos, expected: __state.expected })
 }
 
-pub fn translation_unit<'input>(__input: &'input str, env: &mut Env) -> ParseResult<TranslationUnit> {
+pub fn translation_unit<'input, T: Name>(__input: &'input str, env: &mut Env<T>) -> ParseResult<TranslationUnit<T>> {
     #![allow(non_snake_case, unused)]
     let mut __state = ParseState::new();
     match __parse_translation_unit(__input, &mut __state, 0, env) {

--- a/src/print.rs
+++ b/src/print.rs
@@ -171,7 +171,11 @@ impl<'ast, 'a> Visit<'ast> for Printer<'a> {
         self.name("BinaryOperatorExpression");
         visit_binary_operator_expression(&mut self.block(), n, span);
     }
-    fn visit_conditional_expression(&mut self, n: &'ast ConditionalExpression<String>, span: &'ast Span) {
+    fn visit_conditional_expression(
+        &mut self,
+        n: &'ast ConditionalExpression<String>,
+        span: &'ast Span,
+    ) {
         self.name("ConditionalExpression");
         visit_conditional_expression(&mut self.block(), n, span);
     }
@@ -179,7 +183,11 @@ impl<'ast, 'a> Visit<'ast> for Printer<'a> {
         self.name("VaArgExpression");
         visit_va_arg_expression(&mut self.block(), n, span);
     }
-    fn visit_offset_of_expression(&mut self, n: &'ast OffsetOfExpression<String>, span: &'ast Span) {
+    fn visit_offset_of_expression(
+        &mut self,
+        n: &'ast OffsetOfExpression<String>,
+        span: &'ast Span,
+    ) {
         self.name("OffsetOfExpression");
         visit_offset_of_expression(&mut self.block(), n, span);
     }
@@ -196,7 +204,11 @@ impl<'ast, 'a> Visit<'ast> for Printer<'a> {
         self.name("Declaration");
         visit_declaration(&mut self.block(), n, span);
     }
-    fn visit_declaration_specifier(&mut self, n: &'ast DeclarationSpecifier<String>, span: &'ast Span) {
+    fn visit_declaration_specifier(
+        &mut self,
+        n: &'ast DeclarationSpecifier<String>,
+        span: &'ast Span,
+    ) {
         self.name("DeclarationSpecifier");
         visit_declaration_specifier(&mut self.block(), n, span);
     }
@@ -301,7 +313,11 @@ impl<'ast, 'a> Visit<'ast> for Printer<'a> {
         print_array_size(self, n);
         visit_array_size(&mut self.block(), n, span);
     }
-    fn visit_parameter_declaration(&mut self, n: &'ast ParameterDeclaration<String>, span: &'ast Span) {
+    fn visit_parameter_declaration(
+        &mut self,
+        n: &'ast ParameterDeclaration<String>,
+        span: &'ast Span,
+    ) {
         self.name("ParameterDeclaration");
         visit_parameter_declaration(&mut self.block(), n, span);
     }
@@ -318,7 +334,11 @@ impl<'ast, 'a> Visit<'ast> for Printer<'a> {
         self.name("Initializer");
         visit_initializer(&mut self.block(), n, span);
     }
-    fn visit_initializer_list_item(&mut self, n: &'ast InitializerListItem<String>, span: &'ast Span) {
+    fn visit_initializer_list_item(
+        &mut self,
+        n: &'ast InitializerListItem<String>,
+        span: &'ast Span,
+    ) {
         self.name("InitializerListItem");
         visit_initializer_list_item(&mut self.block(), n, span);
     }
@@ -377,7 +397,11 @@ impl<'ast, 'a> Visit<'ast> for Printer<'a> {
         self.name("BlockItem");
         visit_block_item(&mut self.block(), n, span);
     }
-    fn visit_external_declaration(&mut self, n: &'ast ExternalDeclaration<String>, span: &'ast Span) {
+    fn visit_external_declaration(
+        &mut self,
+        n: &'ast ExternalDeclaration<String>,
+        span: &'ast Span,
+    ) {
         self.name("ExternalDeclaration");
         visit_external_declaration(&mut self.block(), n, span);
     }
@@ -398,7 +422,11 @@ impl<'ast, 'a> Visit<'ast> for Printer<'a> {
         self.name("AsmStatement");
         visit_asm_statement(&mut self.block(), n, span);
     }
-    fn visit_availability_attribute(&mut self, n: &'ast AvailabilityAttribute<String>, span: &'ast Span) {
+    fn visit_availability_attribute(
+        &mut self,
+        n: &'ast AvailabilityAttribute<String>,
+        span: &'ast Span,
+    ) {
         self.name("AvailabilityAttribute");
         visit_availability_attribute(&mut self.block(), n, span);
     }

--- a/src/print.rs
+++ b/src/print.rs
@@ -49,167 +49,167 @@ impl<'a> Printer<'a> {
 }
 
 impl<'ast, 'a> Visit<'ast> for Printer<'a> {
-    fn visit_identifier(&mut self, n: &'ast Identifier, span: &'ast Span) {
+    fn visit_identifier(&mut self, n: &'ast Identifier<String>, span: &'ast Span) {
         self.name("Identifier");
         self.write_field(&n.name);
         visit_identifier(&mut self.block(), n, span);
     }
     fn visit_constant(&mut self, n: &'ast Constant, span: &'ast Span) {
         self.name("Constant");
-        visit_constant(&mut self.block(), n, span);
+        visit_constant::<_, String>(&mut self.block(), n, span);
     }
     fn visit_integer(&mut self, n: &'ast Integer, span: &'ast Span) {
         self.name("Integer");
         self.write_field(&n.number);
-        visit_integer(&mut self.block(), n, span);
+        visit_integer::<_, String>(&mut self.block(), n, span);
     }
     fn visit_integer_base(&mut self, n: &'ast IntegerBase, span: &'ast Span) {
         self.name("IntegerBase");
         self.write_field(&n);
-        visit_integer_base(&mut self.block(), n, span);
+        visit_integer_base::<_, String>(&mut self.block(), n, span);
     }
     fn visit_integer_suffix(&mut self, n: &'ast IntegerSuffix, span: &'ast Span) {
         self.name("IntegerSuffix");
         self.write_field(&n.unsigned);
         self.write_field(&n.imaginary);
-        visit_integer_suffix(&mut self.block(), n, span);
+        visit_integer_suffix::<_, String>(&mut self.block(), n, span);
     }
     fn visit_integer_size(&mut self, n: &'ast IntegerSize, span: &'ast Span) {
         self.name("IntegerSize");
         self.write_field(&n);
-        visit_integer_size(&mut self.block(), n, span);
+        visit_integer_size::<_, String>(&mut self.block(), n, span);
     }
     fn visit_float(&mut self, n: &'ast Float, span: &'ast Span) {
         self.name("Float");
         self.write_field(&n.number);
-        visit_float(&mut self.block(), n, span);
+        visit_float::<_, String>(&mut self.block(), n, span);
     }
     fn visit_float_base(&mut self, n: &'ast FloatBase, span: &'ast Span) {
         self.name("FloatBase");
         self.write_field(&n);
-        visit_float_base(&mut self.block(), n, span);
+        visit_float_base::<_, String>(&mut self.block(), n, span);
     }
     fn visit_float_suffix(&mut self, n: &'ast FloatSuffix, span: &'ast Span) {
         self.name("FloatSuffix");
         self.write_field(&n.imaginary);
-        visit_float_suffix(&mut self.block(), n, span);
+        visit_float_suffix::<_, String>(&mut self.block(), n, span);
     }
     fn visit_float_format(&mut self, n: &'ast FloatFormat, span: &'ast Span) {
         self.name("FloatFormat");
         print_float_format(self, n);
-        visit_float_format(&mut self.block(), n, span);
+        visit_float_format::<_, String>(&mut self.block(), n, span);
     }
     fn visit_string_literal(&mut self, n: &'ast StringLiteral, span: &'ast Span) {
         self.name("StringLiteral");
         self.write_field(&n);
-        visit_string_literal(&mut self.block(), n, span);
+        visit_string_literal::<_, String>(&mut self.block(), n, span);
     }
-    fn visit_expression(&mut self, n: &'ast Expression, span: &'ast Span) {
+    fn visit_expression(&mut self, n: &'ast Expression<String>, span: &'ast Span) {
         self.name("Expression");
         visit_expression(&mut self.block(), n, span);
     }
     fn visit_member_operator(&mut self, n: &'ast MemberOperator, span: &'ast Span) {
         self.name("MemberOperator");
         self.write_field(&n);
-        visit_member_operator(&mut self.block(), n, span);
+        visit_member_operator::<_, String>(&mut self.block(), n, span);
     }
-    fn visit_generic_selection(&mut self, n: &'ast GenericSelection, span: &'ast Span) {
+    fn visit_generic_selection(&mut self, n: &'ast GenericSelection<String>, span: &'ast Span) {
         self.name("GenericSelection");
         visit_generic_selection(&mut self.block(), n, span);
     }
-    fn visit_generic_association(&mut self, n: &'ast GenericAssociation, span: &'ast Span) {
+    fn visit_generic_association(&mut self, n: &'ast GenericAssociation<String>, span: &'ast Span) {
         self.name("GenericAssociation");
         visit_generic_association(&mut self.block(), n, span);
     }
     fn visit_generic_association_type(
         &mut self,
-        n: &'ast GenericAssociationType,
+        n: &'ast GenericAssociationType<String>,
         span: &'ast Span,
     ) {
         self.name("GenericAssociationType");
         visit_generic_association_type(&mut self.block(), n, span);
     }
-    fn visit_member_expression(&mut self, n: &'ast MemberExpression, span: &'ast Span) {
+    fn visit_member_expression(&mut self, n: &'ast MemberExpression<String>, span: &'ast Span) {
         self.name("MemberExpression");
         visit_member_expression(&mut self.block(), n, span);
     }
-    fn visit_call_expression(&mut self, n: &'ast CallExpression, span: &'ast Span) {
+    fn visit_call_expression(&mut self, n: &'ast CallExpression<String>, span: &'ast Span) {
         self.name("CallExpression");
         visit_call_expression(&mut self.block(), n, span);
     }
-    fn visit_compound_literal(&mut self, n: &'ast CompoundLiteral, span: &'ast Span) {
+    fn visit_compound_literal(&mut self, n: &'ast CompoundLiteral<String>, span: &'ast Span) {
         self.name("CompoundLiteral");
         visit_compound_literal(&mut self.block(), n, span);
     }
     fn visit_unary_operator(&mut self, n: &'ast UnaryOperator, span: &'ast Span) {
         self.name("UnaryOperator");
         self.write_field(&n);
-        visit_unary_operator(&mut self.block(), n, span);
+        visit_unary_operator::<_, String>(&mut self.block(), n, span);
     }
     fn visit_unary_operator_expression(
         &mut self,
-        n: &'ast UnaryOperatorExpression,
+        n: &'ast UnaryOperatorExpression<String>,
         span: &'ast Span,
     ) {
         self.name("UnaryOperatorExpression");
         visit_unary_operator_expression(&mut self.block(), n, span);
     }
-    fn visit_cast_expression(&mut self, n: &'ast CastExpression, span: &'ast Span) {
+    fn visit_cast_expression(&mut self, n: &'ast CastExpression<String>, span: &'ast Span) {
         self.name("CastExpression");
         visit_cast_expression(&mut self.block(), n, span);
     }
     fn visit_binary_operator(&mut self, n: &'ast BinaryOperator, span: &'ast Span) {
         self.name("BinaryOperator");
         self.write_field(&n);
-        visit_binary_operator(&mut self.block(), n, span);
+        visit_binary_operator::<_, String>(&mut self.block(), n, span);
     }
     fn visit_binary_operator_expression(
         &mut self,
-        n: &'ast BinaryOperatorExpression,
+        n: &'ast BinaryOperatorExpression<String>,
         span: &'ast Span,
     ) {
         self.name("BinaryOperatorExpression");
         visit_binary_operator_expression(&mut self.block(), n, span);
     }
-    fn visit_conditional_expression(&mut self, n: &'ast ConditionalExpression, span: &'ast Span) {
+    fn visit_conditional_expression(&mut self, n: &'ast ConditionalExpression<String>, span: &'ast Span) {
         self.name("ConditionalExpression");
         visit_conditional_expression(&mut self.block(), n, span);
     }
-    fn visit_va_arg_expression(&mut self, n: &'ast VaArgExpression, span: &'ast Span) {
+    fn visit_va_arg_expression(&mut self, n: &'ast VaArgExpression<String>, span: &'ast Span) {
         self.name("VaArgExpression");
         visit_va_arg_expression(&mut self.block(), n, span);
     }
-    fn visit_offset_of_expression(&mut self, n: &'ast OffsetOfExpression, span: &'ast Span) {
+    fn visit_offset_of_expression(&mut self, n: &'ast OffsetOfExpression<String>, span: &'ast Span) {
         self.name("OffsetOfExpression");
         visit_offset_of_expression(&mut self.block(), n, span);
     }
-    fn visit_offset_designator(&mut self, n: &'ast OffsetDesignator, span: &'ast Span) {
+    fn visit_offset_designator(&mut self, n: &'ast OffsetDesignator<String>, span: &'ast Span) {
         self.name("OffsetDesignator");
         visit_offset_designator(&mut self.block(), n, span);
     }
-    fn visit_offset_member(&mut self, n: &'ast OffsetMember, span: &'ast Span) {
+    fn visit_offset_member(&mut self, n: &'ast OffsetMember<String>, span: &'ast Span) {
         self.name("OffsetMember");
         print_offset_member(self, n);
         visit_offset_member(&mut self.block(), n, span);
     }
-    fn visit_declaration(&mut self, n: &'ast Declaration, span: &'ast Span) {
+    fn visit_declaration(&mut self, n: &'ast Declaration<String>, span: &'ast Span) {
         self.name("Declaration");
         visit_declaration(&mut self.block(), n, span);
     }
-    fn visit_declaration_specifier(&mut self, n: &'ast DeclarationSpecifier, span: &'ast Span) {
+    fn visit_declaration_specifier(&mut self, n: &'ast DeclarationSpecifier<String>, span: &'ast Span) {
         self.name("DeclarationSpecifier");
         visit_declaration_specifier(&mut self.block(), n, span);
     }
-    fn visit_init_declarator(&mut self, n: &'ast InitDeclarator, span: &'ast Span) {
+    fn visit_init_declarator(&mut self, n: &'ast InitDeclarator<String>, span: &'ast Span) {
         self.name("InitDeclarator");
         visit_init_declarator(&mut self.block(), n, span);
     }
     fn visit_storage_class_specifier(&mut self, n: &'ast StorageClassSpecifier, span: &'ast Span) {
         self.name("StorageClassSpecifier");
         self.write_field(&n);
-        visit_storage_class_specifier(&mut self.block(), n, span);
+        visit_storage_class_specifier::<_, String>(&mut self.block(), n, span);
     }
-    fn visit_type_specifier(&mut self, n: &'ast TypeSpecifier, span: &'ast Span) {
+    fn visit_type_specifier(&mut self, n: &'ast TypeSpecifier<String>, span: &'ast Span) {
         self.name("TypeSpecifier");
         print_type_specifier(self, n);
         visit_type_specifier(&mut self.block(), n, span);
@@ -217,208 +217,208 @@ impl<'ast, 'a> Visit<'ast> for Printer<'a> {
     fn visit_ts18661_float_type(&mut self, n: &'ast TS18661FloatType, span: &'ast Span) {
         self.name("TS18661FloatType");
         self.write_field(&n.width);
-        visit_ts18661_float_type(&mut self.block(), n, span);
+        visit_ts18661_float_type::<_, String>(&mut self.block(), n, span);
     }
     fn visit_ts18661_float_format(&mut self, n: &'ast TS18661FloatFormat, span: &'ast Span) {
         self.name("TS18661FloatFormat");
         self.write_field(&n);
-        visit_ts18661_float_format(&mut self.block(), n, span);
+        visit_ts18661_float_format::<_, String>(&mut self.block(), n, span);
     }
-    fn visit_struct_type(&mut self, n: &'ast StructType, span: &'ast Span) {
+    fn visit_struct_type(&mut self, n: &'ast StructType<String>, span: &'ast Span) {
         self.name("StructType");
         visit_struct_type(&mut self.block(), n, span);
     }
     fn visit_struct_kind(&mut self, n: &'ast StructKind, span: &'ast Span) {
         self.name("StructKind");
         self.write_field(&n);
-        visit_struct_kind(&mut self.block(), n, span);
+        visit_struct_kind::<_, String>(&mut self.block(), n, span);
     }
-    fn visit_struct_declaration(&mut self, n: &'ast StructDeclaration, span: &'ast Span) {
+    fn visit_struct_declaration(&mut self, n: &'ast StructDeclaration<String>, span: &'ast Span) {
         self.name("StructDeclaration");
         visit_struct_declaration(&mut self.block(), n, span);
     }
-    fn visit_struct_field(&mut self, n: &'ast StructField, span: &'ast Span) {
+    fn visit_struct_field(&mut self, n: &'ast StructField<String>, span: &'ast Span) {
         self.name("StructField");
         visit_struct_field(&mut self.block(), n, span);
     }
-    fn visit_specifier_qualifier(&mut self, n: &'ast SpecifierQualifier, span: &'ast Span) {
+    fn visit_specifier_qualifier(&mut self, n: &'ast SpecifierQualifier<String>, span: &'ast Span) {
         self.name("SpecifierQualifier");
         visit_specifier_qualifier(&mut self.block(), n, span);
     }
-    fn visit_struct_declarator(&mut self, n: &'ast StructDeclarator, span: &'ast Span) {
+    fn visit_struct_declarator(&mut self, n: &'ast StructDeclarator<String>, span: &'ast Span) {
         self.name("StructDeclarator");
         visit_struct_declarator(&mut self.block(), n, span);
     }
-    fn visit_enum_type(&mut self, n: &'ast EnumType, span: &'ast Span) {
+    fn visit_enum_type(&mut self, n: &'ast EnumType<String>, span: &'ast Span) {
         self.name("EnumType");
         visit_enum_type(&mut self.block(), n, span);
     }
-    fn visit_enumerator(&mut self, n: &'ast Enumerator, span: &'ast Span) {
+    fn visit_enumerator(&mut self, n: &'ast Enumerator<String>, span: &'ast Span) {
         self.name("Enumerator");
         visit_enumerator(&mut self.block(), n, span);
     }
     fn visit_type_qualifier(&mut self, n: &'ast TypeQualifier, span: &'ast Span) {
         self.name("TypeQualifier");
         self.write_field(&n);
-        visit_type_qualifier(&mut self.block(), n, span);
+        visit_type_qualifier::<_, String>(&mut self.block(), n, span);
     }
     fn visit_function_specifier(&mut self, n: &'ast FunctionSpecifier, span: &'ast Span) {
         self.name("FunctionSpecifier");
         self.write_field(&n);
-        visit_function_specifier(&mut self.block(), n, span);
+        visit_function_specifier::<_, String>(&mut self.block(), n, span);
     }
-    fn visit_alignment_specifier(&mut self, n: &'ast AlignmentSpecifier, span: &'ast Span) {
+    fn visit_alignment_specifier(&mut self, n: &'ast AlignmentSpecifier<String>, span: &'ast Span) {
         self.name("AlignmentSpecifier");
         visit_alignment_specifier(&mut self.block(), n, span);
     }
-    fn visit_declarator(&mut self, n: &'ast Declarator, span: &'ast Span) {
+    fn visit_declarator(&mut self, n: &'ast Declarator<String>, span: &'ast Span) {
         self.name("Declarator");
         visit_declarator(&mut self.block(), n, span);
     }
-    fn visit_declarator_kind(&mut self, n: &'ast DeclaratorKind, span: &'ast Span) {
+    fn visit_declarator_kind(&mut self, n: &'ast DeclaratorKind<String>, span: &'ast Span) {
         self.name("DeclaratorKind");
         print_declarator_kind(self, n);
         visit_declarator_kind(&mut self.block(), n, span);
     }
-    fn visit_derived_declarator(&mut self, n: &'ast DerivedDeclarator, span: &'ast Span) {
+    fn visit_derived_declarator(&mut self, n: &'ast DerivedDeclarator<String>, span: &'ast Span) {
         self.name("DerivedDeclarator");
         visit_derived_declarator(&mut self.block(), n, span);
     }
-    fn visit_array_declarator(&mut self, n: &'ast ArrayDeclarator, span: &'ast Span) {
+    fn visit_array_declarator(&mut self, n: &'ast ArrayDeclarator<String>, span: &'ast Span) {
         self.name("ArrayDeclarator");
         visit_array_declarator(&mut self.block(), n, span);
     }
-    fn visit_function_declarator(&mut self, n: &'ast FunctionDeclarator, span: &'ast Span) {
+    fn visit_function_declarator(&mut self, n: &'ast FunctionDeclarator<String>, span: &'ast Span) {
         self.name("FunctionDeclarator");
         visit_function_declarator(&mut self.block(), n, span);
     }
-    fn visit_pointer_qualifier(&mut self, n: &'ast PointerQualifier, span: &'ast Span) {
+    fn visit_pointer_qualifier(&mut self, n: &'ast PointerQualifier<String>, span: &'ast Span) {
         self.name("PointerQualifier");
         visit_pointer_qualifier(&mut self.block(), n, span);
     }
-    fn visit_array_size(&mut self, n: &'ast ArraySize, span: &'ast Span) {
+    fn visit_array_size(&mut self, n: &'ast ArraySize<String>, span: &'ast Span) {
         self.name("ArraySize");
         print_array_size(self, n);
         visit_array_size(&mut self.block(), n, span);
     }
-    fn visit_parameter_declaration(&mut self, n: &'ast ParameterDeclaration, span: &'ast Span) {
+    fn visit_parameter_declaration(&mut self, n: &'ast ParameterDeclaration<String>, span: &'ast Span) {
         self.name("ParameterDeclaration");
         visit_parameter_declaration(&mut self.block(), n, span);
     }
     fn visit_ellipsis(&mut self, n: &'ast Ellipsis, span: &'ast Span) {
         self.name("Ellipsis");
         self.write_field(&n);
-        visit_ellipsis(&mut self.block(), n, span);
+        visit_ellipsis::<_, String>(&mut self.block(), n, span);
     }
-    fn visit_type_name(&mut self, n: &'ast TypeName, span: &'ast Span) {
+    fn visit_type_name(&mut self, n: &'ast TypeName<String>, span: &'ast Span) {
         self.name("TypeName");
         visit_type_name(&mut self.block(), n, span);
     }
-    fn visit_initializer(&mut self, n: &'ast Initializer, span: &'ast Span) {
+    fn visit_initializer(&mut self, n: &'ast Initializer<String>, span: &'ast Span) {
         self.name("Initializer");
         visit_initializer(&mut self.block(), n, span);
     }
-    fn visit_initializer_list_item(&mut self, n: &'ast InitializerListItem, span: &'ast Span) {
+    fn visit_initializer_list_item(&mut self, n: &'ast InitializerListItem<String>, span: &'ast Span) {
         self.name("InitializerListItem");
         visit_initializer_list_item(&mut self.block(), n, span);
     }
-    fn visit_designator(&mut self, n: &'ast Designator, span: &'ast Span) {
+    fn visit_designator(&mut self, n: &'ast Designator<String>, span: &'ast Span) {
         self.name("Designator");
         visit_designator(&mut self.block(), n, span);
     }
-    fn visit_range_designator(&mut self, n: &'ast RangeDesignator, span: &'ast Span) {
+    fn visit_range_designator(&mut self, n: &'ast RangeDesignator<String>, span: &'ast Span) {
         self.name("RangeDesignator");
         visit_range_designator(&mut self.block(), n, span);
     }
-    fn visit_static_assert(&mut self, n: &'ast StaticAssert, span: &'ast Span) {
+    fn visit_static_assert(&mut self, n: &'ast StaticAssert<String>, span: &'ast Span) {
         self.name("StaticAssert");
         visit_static_assert(&mut self.block(), n, span);
     }
-    fn visit_statement(&mut self, n: &'ast Statement, span: &'ast Span) {
+    fn visit_statement(&mut self, n: &'ast Statement<String>, span: &'ast Span) {
         self.name("Statement");
         print_statement(self, n);
         visit_statement(&mut self.block(), n, span);
     }
-    fn visit_labeled_statement(&mut self, n: &'ast LabeledStatement, span: &'ast Span) {
+    fn visit_labeled_statement(&mut self, n: &'ast LabeledStatement<String>, span: &'ast Span) {
         self.name("LabeledStatement");
         visit_labeled_statement(&mut self.block(), n, span);
     }
-    fn visit_if_statement(&mut self, n: &'ast IfStatement, span: &'ast Span) {
+    fn visit_if_statement(&mut self, n: &'ast IfStatement<String>, span: &'ast Span) {
         self.name("IfStatement");
         visit_if_statement(&mut self.block(), n, span);
     }
-    fn visit_switch_statement(&mut self, n: &'ast SwitchStatement, span: &'ast Span) {
+    fn visit_switch_statement(&mut self, n: &'ast SwitchStatement<String>, span: &'ast Span) {
         self.name("SwitchStatement");
         visit_switch_statement(&mut self.block(), n, span);
     }
-    fn visit_while_statement(&mut self, n: &'ast WhileStatement, span: &'ast Span) {
+    fn visit_while_statement(&mut self, n: &'ast WhileStatement<String>, span: &'ast Span) {
         self.name("WhileStatement");
         visit_while_statement(&mut self.block(), n, span);
     }
-    fn visit_do_while_statement(&mut self, n: &'ast DoWhileStatement, span: &'ast Span) {
+    fn visit_do_while_statement(&mut self, n: &'ast DoWhileStatement<String>, span: &'ast Span) {
         self.name("DoWhileStatement");
         visit_do_while_statement(&mut self.block(), n, span);
     }
-    fn visit_for_statement(&mut self, n: &'ast ForStatement, span: &'ast Span) {
+    fn visit_for_statement(&mut self, n: &'ast ForStatement<String>, span: &'ast Span) {
         self.name("ForStatement");
         visit_for_statement(&mut self.block(), n, span);
     }
-    fn visit_label(&mut self, n: &'ast Label, span: &'ast Span) {
+    fn visit_label(&mut self, n: &'ast Label<String>, span: &'ast Span) {
         self.name("Label");
         print_label(self, n);
         visit_label(&mut self.block(), n, span);
     }
-    fn visit_for_initializer(&mut self, n: &'ast ForInitializer, span: &'ast Span) {
+    fn visit_for_initializer(&mut self, n: &'ast ForInitializer<String>, span: &'ast Span) {
         self.name("ForInitializer");
         print_for_initializer(self, n);
         visit_for_initializer(&mut self.block(), n, span);
     }
-    fn visit_block_item(&mut self, n: &'ast BlockItem, span: &'ast Span) {
+    fn visit_block_item(&mut self, n: &'ast BlockItem<String>, span: &'ast Span) {
         self.name("BlockItem");
         visit_block_item(&mut self.block(), n, span);
     }
-    fn visit_external_declaration(&mut self, n: &'ast ExternalDeclaration, span: &'ast Span) {
+    fn visit_external_declaration(&mut self, n: &'ast ExternalDeclaration<String>, span: &'ast Span) {
         self.name("ExternalDeclaration");
         visit_external_declaration(&mut self.block(), n, span);
     }
-    fn visit_function_definition(&mut self, n: &'ast FunctionDefinition, span: &'ast Span) {
+    fn visit_function_definition(&mut self, n: &'ast FunctionDefinition<String>, span: &'ast Span) {
         self.name("FunctionDefinition");
         visit_function_definition(&mut self.block(), n, span);
     }
-    fn visit_extension(&mut self, n: &'ast Extension, span: &'ast Span) {
+    fn visit_extension(&mut self, n: &'ast Extension<String>, span: &'ast Span) {
         self.name("Extension");
         visit_extension(&mut self.block(), n, span);
     }
-    fn visit_attribute(&mut self, n: &'ast Attribute, span: &'ast Span) {
+    fn visit_attribute(&mut self, n: &'ast Attribute<String>, span: &'ast Span) {
         self.name("Attribute");
         self.write_field(&n.name.node);
         visit_attribute(&mut self.block(), n, span);
     }
-    fn visit_asm_statement(&mut self, n: &'ast AsmStatement, span: &'ast Span) {
+    fn visit_asm_statement(&mut self, n: &'ast AsmStatement<String>, span: &'ast Span) {
         self.name("AsmStatement");
         visit_asm_statement(&mut self.block(), n, span);
     }
-    fn visit_availability_attribute(&mut self, n: &'ast AvailabilityAttribute, span: &'ast Span) {
+    fn visit_availability_attribute(&mut self, n: &'ast AvailabilityAttribute<String>, span: &'ast Span) {
         self.name("AvailabilityAttribute");
         visit_availability_attribute(&mut self.block(), n, span);
     }
     fn visit_gnu_extended_asm_statement(
         &mut self,
-        n: &'ast GnuExtendedAsmStatement,
+        n: &'ast GnuExtendedAsmStatement<String>,
         span: &'ast Span,
     ) {
         self.name("GnuExtendedAsmStatement");
         visit_gnu_extended_asm_statement(&mut self.block(), n, span);
     }
-    fn visit_gnu_asm_operand(&mut self, n: &'ast GnuAsmOperand, span: &'ast Span) {
+    fn visit_gnu_asm_operand(&mut self, n: &'ast GnuAsmOperand<String>, span: &'ast Span) {
         self.name("GnuAsmOperand");
         visit_gnu_asm_operand(&mut self.block(), n, span);
     }
-    fn visit_type_of(&mut self, n: &'ast TypeOf, span: &'ast Span) {
+    fn visit_type_of(&mut self, n: &'ast TypeOf<String>, span: &'ast Span) {
         self.name("TypeOf");
         visit_type_of(&mut self.block(), n, span);
     }
-    fn visit_translation_unit(&mut self, translation_unit: &'ast TranslationUnit) {
+    fn visit_translation_unit(&mut self, translation_unit: &'ast TranslationUnit<String>) {
         self.name("TranslationUnit");
         visit_translation_unit(&mut self.block(), translation_unit);
     }
@@ -432,13 +432,13 @@ fn print_float_format<'ast>(p: &mut Printer, n: &'ast FloatFormat) {
         _ => {}
     }
 }
-fn print_declarator_kind<'ast>(p: &mut Printer, n: &'ast DeclaratorKind) {
+fn print_declarator_kind<'ast>(p: &mut Printer, n: &'ast DeclaratorKind<impl Name>) {
     match *n {
         DeclaratorKind::Abstract => p.w.write_str(" Abstract").unwrap(),
         _ => {}
     }
 }
-fn print_array_size<'ast>(p: &mut Printer, n: &'ast ArraySize) {
+fn print_array_size<'ast>(p: &mut Printer, n: &'ast ArraySize<impl Name>) {
     match *n {
         ArraySize::Unknown => p.w.write_str(" Unknown").unwrap(),
         ArraySize::VariableUnknown => p.w.write_str(" VariableUnknown").unwrap(),
@@ -446,7 +446,7 @@ fn print_array_size<'ast>(p: &mut Printer, n: &'ast ArraySize) {
         ArraySize::StaticExpression(_) => p.w.write_str(" StaticExpression").unwrap(),
     }
 }
-fn print_statement<'ast>(p: &mut Printer, n: &'ast Statement) {
+fn print_statement<'ast>(p: &mut Printer, n: &'ast Statement<impl Name>) {
     match *n {
         Statement::Compound(_) => p.w.write_str(" Compound").unwrap(),
         Statement::Goto(_) => p.w.write_str(" Goto").unwrap(),
@@ -456,26 +456,26 @@ fn print_statement<'ast>(p: &mut Printer, n: &'ast Statement) {
         _ => {}
     }
 }
-fn print_offset_member<'ast>(p: &mut Printer, n: &'ast OffsetMember) {
+fn print_offset_member<'ast>(p: &mut Printer, n: &'ast OffsetMember<impl Name>) {
     match *n {
         OffsetMember::Member(_) => p.w.write_str(" Member").unwrap(),
         OffsetMember::IndirectMember(_) => p.w.write_str(" IndirectMember").unwrap(),
         _ => {}
     }
 }
-fn print_label<'ast>(p: &mut Printer, n: &'ast Label) {
+fn print_label<'ast>(p: &mut Printer, n: &'ast Label<impl Name>) {
     match *n {
         Label::Default => p.w.write_str(" Default").unwrap(),
         _ => {}
     }
 }
-fn print_for_initializer<'ast>(p: &mut Printer, n: &'ast ForInitializer) {
+fn print_for_initializer<'ast>(p: &mut Printer, n: &'ast ForInitializer<impl Name>) {
     match *n {
         ForInitializer::Empty => p.w.write_str(" Empty").unwrap(),
         _ => {}
     }
 }
-fn print_type_specifier<'ast>(p: &mut Printer, n: &'ast TypeSpecifier) {
+fn print_type_specifier<'ast>(p: &mut Printer, n: &'ast TypeSpecifier<impl Name>) {
     match *n {
         TypeSpecifier::Void => p.w.write_str(" Void").unwrap(),
         TypeSpecifier::Char => p.w.write_str(" Char").unwrap(),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -70,7 +70,7 @@ impl Case {
     }
 
     fn run(&self) -> bool {
-        let mut env = None;
+        let mut env: Option<Env<String>> = None;
 
         for pragma in &self.pragma {
             match *pragma {
@@ -202,7 +202,7 @@ impl Kind {
         })
     }
 
-    fn parse_and_print(&self, source: &str, env: &mut Env) -> Result<String, parser::ParseError> {
+    fn parse_and_print(&self, source: &str, env: &mut Env<String>) -> Result<String, parser::ParseError> {
         let source = source.trim_right();
 
         let mut s = "".to_string();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -202,7 +202,11 @@ impl Kind {
         })
     }
 
-    fn parse_and_print(&self, source: &str, env: &mut Env<String>) -> Result<String, parser::ParseError> {
+    fn parse_and_print(
+        &self,
+        source: &str,
+        env: &mut Env<String>,
+    ) -> Result<String, parser::ParseError> {
         let source = source.trim_right();
 
         let mut s = "".to_string();

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -21,8 +21,8 @@
 use ast::*;
 use span::Span;
 
-pub trait Visit<'ast> {
-    fn visit_identifier(&mut self, identifier: &'ast Identifier, span: &'ast Span) {
+pub trait Visit<'ast, T: Name = String> {
+    fn visit_identifier(&mut self, identifier: &'ast Identifier<T>, span: &'ast Span) {
         visit_identifier(self, identifier, span)
     }
 
@@ -66,7 +66,7 @@ pub trait Visit<'ast> {
         visit_string_literal(self, string_literal, span)
     }
 
-    fn visit_expression(&mut self, expression: &'ast Expression, span: &'ast Span) {
+    fn visit_expression(&mut self, expression: &'ast Expression<T>, span: &'ast Span) {
         visit_expression(self, expression, span)
     }
 
@@ -76,7 +76,7 @@ pub trait Visit<'ast> {
 
     fn visit_generic_selection(
         &mut self,
-        generic_selection: &'ast GenericSelection,
+        generic_selection: &'ast GenericSelection<T>,
         span: &'ast Span,
     ) {
         visit_generic_selection(self, generic_selection, span)
@@ -84,7 +84,7 @@ pub trait Visit<'ast> {
 
     fn visit_generic_association(
         &mut self,
-        generic_association: &'ast GenericAssociation,
+        generic_association: &'ast GenericAssociation<T>,
         span: &'ast Span,
     ) {
         visit_generic_association(self, generic_association, span)
@@ -92,7 +92,7 @@ pub trait Visit<'ast> {
 
     fn visit_generic_association_type(
         &mut self,
-        generic_association_type: &'ast GenericAssociationType,
+        generic_association_type: &'ast GenericAssociationType<T>,
         span: &'ast Span,
     ) {
         visit_generic_association_type(self, generic_association_type, span)
@@ -100,19 +100,19 @@ pub trait Visit<'ast> {
 
     fn visit_member_expression(
         &mut self,
-        member_expression: &'ast MemberExpression,
+        member_expression: &'ast MemberExpression<T>,
         span: &'ast Span,
     ) {
         visit_member_expression(self, member_expression, span)
     }
 
-    fn visit_call_expression(&mut self, call_expression: &'ast CallExpression, span: &'ast Span) {
+    fn visit_call_expression(&mut self, call_expression: &'ast CallExpression<T>, span: &'ast Span) {
         visit_call_expression(self, call_expression, span)
     }
 
     fn visit_compound_literal(
         &mut self,
-        compound_literal: &'ast CompoundLiteral,
+        compound_literal: &'ast CompoundLiteral<T>,
         span: &'ast Span,
     ) {
         visit_compound_literal(self, compound_literal, span)
@@ -124,13 +124,13 @@ pub trait Visit<'ast> {
 
     fn visit_unary_operator_expression(
         &mut self,
-        unary_operator_expression: &'ast UnaryOperatorExpression,
+        unary_operator_expression: &'ast UnaryOperatorExpression<T>,
         span: &'ast Span,
     ) {
         visit_unary_operator_expression(self, unary_operator_expression, span)
     }
 
-    fn visit_cast_expression(&mut self, cast_expression: &'ast CastExpression, span: &'ast Span) {
+    fn visit_cast_expression(&mut self, cast_expression: &'ast CastExpression<T>, span: &'ast Span) {
         visit_cast_expression(self, cast_expression, span)
     }
 
@@ -140,7 +140,7 @@ pub trait Visit<'ast> {
 
     fn visit_binary_operator_expression(
         &mut self,
-        binary_operator_expression: &'ast BinaryOperatorExpression,
+        binary_operator_expression: &'ast BinaryOperatorExpression<T>,
         span: &'ast Span,
     ) {
         visit_binary_operator_expression(self, binary_operator_expression, span)
@@ -148,7 +148,7 @@ pub trait Visit<'ast> {
 
     fn visit_conditional_expression(
         &mut self,
-        conditional_expression: &'ast ConditionalExpression,
+        conditional_expression: &'ast ConditionalExpression<T>,
         span: &'ast Span,
     ) {
         visit_conditional_expression(self, conditional_expression, span)
@@ -156,7 +156,7 @@ pub trait Visit<'ast> {
 
     fn visit_va_arg_expression(
         &mut self,
-        va_arg_expression: &'ast VaArgExpression,
+        va_arg_expression: &'ast VaArgExpression<T>,
         span: &'ast Span,
     ) {
         visit_va_arg_expression(self, va_arg_expression, span)
@@ -164,7 +164,7 @@ pub trait Visit<'ast> {
 
     fn visit_offset_of_expression(
         &mut self,
-        offset_of_expression: &'ast OffsetOfExpression,
+        offset_of_expression: &'ast OffsetOfExpression<T>,
         span: &'ast Span,
     ) {
         visit_offset_of_expression(self, offset_of_expression, span)
@@ -172,29 +172,29 @@ pub trait Visit<'ast> {
 
     fn visit_offset_designator(
         &mut self,
-        offset_designator: &'ast OffsetDesignator,
+        offset_designator: &'ast OffsetDesignator<T>,
         span: &'ast Span,
     ) {
         visit_offset_designator(self, offset_designator, span)
     }
 
-    fn visit_offset_member(&mut self, offset_member: &'ast OffsetMember, span: &'ast Span) {
+    fn visit_offset_member(&mut self, offset_member: &'ast OffsetMember<T>, span: &'ast Span) {
         visit_offset_member(self, offset_member, span)
     }
 
-    fn visit_declaration(&mut self, declaration: &'ast Declaration, span: &'ast Span) {
+    fn visit_declaration(&mut self, declaration: &'ast Declaration<T>, span: &'ast Span) {
         visit_declaration(self, declaration, span)
     }
 
     fn visit_declaration_specifier(
         &mut self,
-        declaration_specifier: &'ast DeclarationSpecifier,
+        declaration_specifier: &'ast DeclarationSpecifier<T>,
         span: &'ast Span,
     ) {
         visit_declaration_specifier(self, declaration_specifier, span)
     }
 
-    fn visit_init_declarator(&mut self, init_declarator: &'ast InitDeclarator, span: &'ast Span) {
+    fn visit_init_declarator(&mut self, init_declarator: &'ast InitDeclarator<T>, span: &'ast Span) {
         visit_init_declarator(self, init_declarator, span)
     }
 
@@ -206,7 +206,7 @@ pub trait Visit<'ast> {
         visit_storage_class_specifier(self, storage_class_specifier, span)
     }
 
-    fn visit_type_specifier(&mut self, type_specifier: &'ast TypeSpecifier, span: &'ast Span) {
+    fn visit_type_specifier(&mut self, type_specifier: &'ast TypeSpecifier<T>, span: &'ast Span) {
         visit_type_specifier(self, type_specifier, span)
     }
 
@@ -226,7 +226,7 @@ pub trait Visit<'ast> {
         visit_ts18661_float_format(self, ts18661_float_format, span)
     }
 
-    fn visit_struct_type(&mut self, struct_type: &'ast StructType, span: &'ast Span) {
+    fn visit_struct_type(&mut self, struct_type: &'ast StructType<T>, span: &'ast Span) {
         visit_struct_type(self, struct_type, span)
     }
 
@@ -236,19 +236,19 @@ pub trait Visit<'ast> {
 
     fn visit_struct_declaration(
         &mut self,
-        struct_declaration: &'ast StructDeclaration,
+        struct_declaration: &'ast StructDeclaration<T>,
         span: &'ast Span,
     ) {
         visit_struct_declaration(self, struct_declaration, span)
     }
 
-    fn visit_struct_field(&mut self, struct_field: &'ast StructField, span: &'ast Span) {
+    fn visit_struct_field(&mut self, struct_field: &'ast StructField<T>, span: &'ast Span) {
         visit_struct_field(self, struct_field, span)
     }
 
     fn visit_specifier_qualifier(
         &mut self,
-        specifier_qualifier: &'ast SpecifierQualifier,
+        specifier_qualifier: &'ast SpecifierQualifier<T>,
         span: &'ast Span,
     ) {
         visit_specifier_qualifier(self, specifier_qualifier, span)
@@ -256,17 +256,17 @@ pub trait Visit<'ast> {
 
     fn visit_struct_declarator(
         &mut self,
-        struct_declarator: &'ast StructDeclarator,
+        struct_declarator: &'ast StructDeclarator<T>,
         span: &'ast Span,
     ) {
         visit_struct_declarator(self, struct_declarator, span)
     }
 
-    fn visit_enum_type(&mut self, enum_type: &'ast EnumType, span: &'ast Span) {
+    fn visit_enum_type(&mut self, enum_type: &'ast EnumType<T>, span: &'ast Span) {
         visit_enum_type(self, enum_type, span)
     }
 
-    fn visit_enumerator(&mut self, enumerator: &'ast Enumerator, span: &'ast Span) {
+    fn visit_enumerator(&mut self, enumerator: &'ast Enumerator<T>, span: &'ast Span) {
         visit_enumerator(self, enumerator, span)
     }
 
@@ -284,23 +284,23 @@ pub trait Visit<'ast> {
 
     fn visit_alignment_specifier(
         &mut self,
-        alignment_specifier: &'ast AlignmentSpecifier,
+        alignment_specifier: &'ast AlignmentSpecifier<T>,
         span: &'ast Span,
     ) {
         visit_alignment_specifier(self, alignment_specifier, span)
     }
 
-    fn visit_declarator(&mut self, declarator: &'ast Declarator, span: &'ast Span) {
+    fn visit_declarator(&mut self, declarator: &'ast Declarator<T>, span: &'ast Span) {
         visit_declarator(self, declarator, span)
     }
 
-    fn visit_declarator_kind(&mut self, declarator_kind: &'ast DeclaratorKind, span: &'ast Span) {
+    fn visit_declarator_kind(&mut self, declarator_kind: &'ast DeclaratorKind<T>, span: &'ast Span) {
         visit_declarator_kind(self, declarator_kind, span)
     }
 
     fn visit_derived_declarator(
         &mut self,
-        derived_declarator: &'ast DerivedDeclarator,
+        derived_declarator: &'ast DerivedDeclarator<T>,
         span: &'ast Span,
     ) {
         visit_derived_declarator(self, derived_declarator, span)
@@ -308,7 +308,7 @@ pub trait Visit<'ast> {
 
     fn visit_array_declarator(
         &mut self,
-        array_declarator: &'ast ArrayDeclarator,
+        array_declarator: &'ast ArrayDeclarator<T>,
         span: &'ast Span,
     ) {
         visit_array_declarator(self, array_declarator, span)
@@ -316,7 +316,7 @@ pub trait Visit<'ast> {
 
     fn visit_function_declarator(
         &mut self,
-        function_declarator: &'ast FunctionDeclarator,
+        function_declarator: &'ast FunctionDeclarator<T>,
         span: &'ast Span,
     ) {
         visit_function_declarator(self, function_declarator, span)
@@ -324,19 +324,19 @@ pub trait Visit<'ast> {
 
     fn visit_pointer_qualifier(
         &mut self,
-        pointer_qualifier: &'ast PointerQualifier,
+        pointer_qualifier: &'ast PointerQualifier<T>,
         span: &'ast Span,
     ) {
         visit_pointer_qualifier(self, pointer_qualifier, span)
     }
 
-    fn visit_array_size(&mut self, array_size: &'ast ArraySize, span: &'ast Span) {
+    fn visit_array_size(&mut self, array_size: &'ast ArraySize<T>, span: &'ast Span) {
         visit_array_size(self, array_size, span)
     }
 
     fn visit_parameter_declaration(
         &mut self,
-        parameter_declaration: &'ast ParameterDeclaration,
+        parameter_declaration: &'ast ParameterDeclaration<T>,
         span: &'ast Span,
     ) {
         visit_parameter_declaration(self, parameter_declaration, span)
@@ -346,97 +346,97 @@ pub trait Visit<'ast> {
         visit_ellipsis(self, ellipsis, span)
     }
 
-    fn visit_type_name(&mut self, type_name: &'ast TypeName, span: &'ast Span) {
+    fn visit_type_name(&mut self, type_name: &'ast TypeName<T>, span: &'ast Span) {
         visit_type_name(self, type_name, span)
     }
 
-    fn visit_initializer(&mut self, initializer: &'ast Initializer, span: &'ast Span) {
+    fn visit_initializer(&mut self, initializer: &'ast Initializer<T>, span: &'ast Span) {
         visit_initializer(self, initializer, span)
     }
 
     fn visit_initializer_list_item(
         &mut self,
-        initializer_list_item: &'ast InitializerListItem,
+        initializer_list_item: &'ast InitializerListItem<T>,
         span: &'ast Span,
     ) {
         visit_initializer_list_item(self, initializer_list_item, span)
     }
 
-    fn visit_designator(&mut self, designator: &'ast Designator, span: &'ast Span) {
+    fn visit_designator(&mut self, designator: &'ast Designator<T>, span: &'ast Span) {
         visit_designator(self, designator, span)
     }
 
     fn visit_range_designator(
         &mut self,
-        range_designator: &'ast RangeDesignator,
+        range_designator: &'ast RangeDesignator<T>,
         span: &'ast Span,
     ) {
         visit_range_designator(self, range_designator, span)
     }
 
-    fn visit_static_assert(&mut self, static_assert: &'ast StaticAssert, span: &'ast Span) {
+    fn visit_static_assert(&mut self, static_assert: &'ast StaticAssert<T>, span: &'ast Span) {
         visit_static_assert(self, static_assert, span)
     }
 
-    fn visit_statement(&mut self, statement: &'ast Statement, span: &'ast Span) {
+    fn visit_statement(&mut self, statement: &'ast Statement<T>, span: &'ast Span) {
         visit_statement(self, statement, span)
     }
 
     fn visit_labeled_statement(
         &mut self,
-        labeled_statement: &'ast LabeledStatement,
+        labeled_statement: &'ast LabeledStatement<T>,
         span: &'ast Span,
     ) {
         visit_labeled_statement(self, labeled_statement, span)
     }
 
-    fn visit_if_statement(&mut self, if_statement: &'ast IfStatement, span: &'ast Span) {
+    fn visit_if_statement(&mut self, if_statement: &'ast IfStatement<T>, span: &'ast Span) {
         visit_if_statement(self, if_statement, span)
     }
 
     fn visit_switch_statement(
         &mut self,
-        switch_statement: &'ast SwitchStatement,
+        switch_statement: &'ast SwitchStatement<T>,
         span: &'ast Span,
     ) {
         visit_switch_statement(self, switch_statement, span)
     }
 
-    fn visit_while_statement(&mut self, while_statement: &'ast WhileStatement, span: &'ast Span) {
+    fn visit_while_statement(&mut self, while_statement: &'ast WhileStatement<T>, span: &'ast Span) {
         visit_while_statement(self, while_statement, span)
     }
 
     fn visit_do_while_statement(
         &mut self,
-        do_while_statement: &'ast DoWhileStatement,
+        do_while_statement: &'ast DoWhileStatement<T>,
         span: &'ast Span,
     ) {
         visit_do_while_statement(self, do_while_statement, span)
     }
 
-    fn visit_for_statement(&mut self, for_statement: &'ast ForStatement, span: &'ast Span) {
+    fn visit_for_statement(&mut self, for_statement: &'ast ForStatement<T>, span: &'ast Span) {
         visit_for_statement(self, for_statement, span)
     }
 
-    fn visit_label(&mut self, label: &'ast Label, span: &'ast Span) {
+    fn visit_label(&mut self, label: &'ast Label<T>, span: &'ast Span) {
         visit_label(self, label, span)
     }
 
-    fn visit_for_initializer(&mut self, for_initializer: &'ast ForInitializer, span: &'ast Span) {
+    fn visit_for_initializer(&mut self, for_initializer: &'ast ForInitializer<T>, span: &'ast Span) {
         visit_for_initializer(self, for_initializer, span)
     }
 
-    fn visit_block_item(&mut self, block_item: &'ast BlockItem, span: &'ast Span) {
+    fn visit_block_item(&mut self, block_item: &'ast BlockItem<T>, span: &'ast Span) {
         visit_block_item(self, block_item, span)
     }
 
-    fn visit_translation_unit(&mut self, translation_unit: &'ast TranslationUnit) {
+    fn visit_translation_unit(&mut self, translation_unit: &'ast TranslationUnit<T>) {
         visit_translation_unit(self, translation_unit)
     }
 
     fn visit_external_declaration(
         &mut self,
-        external_declaration: &'ast ExternalDeclaration,
+        external_declaration: &'ast ExternalDeclaration<T>,
         span: &'ast Span,
     ) {
         visit_external_declaration(self, external_declaration, span)
@@ -444,27 +444,27 @@ pub trait Visit<'ast> {
 
     fn visit_function_definition(
         &mut self,
-        function_definition: &'ast FunctionDefinition,
+        function_definition: &'ast FunctionDefinition<T>,
         span: &'ast Span,
     ) {
         visit_function_definition(self, function_definition, span)
     }
 
-    fn visit_extension(&mut self, extension: &'ast Extension, span: &'ast Span) {
+    fn visit_extension(&mut self, extension: &'ast Extension<T>, span: &'ast Span) {
         visit_extension(self, extension, span)
     }
 
-    fn visit_attribute(&mut self, attribute: &'ast Attribute, span: &'ast Span) {
+    fn visit_attribute(&mut self, attribute: &'ast Attribute<T>, span: &'ast Span) {
         visit_attribute(self, attribute, span)
     }
 
-    fn visit_asm_statement(&mut self, asm_statement: &'ast AsmStatement, span: &'ast Span) {
+    fn visit_asm_statement(&mut self, asm_statement: &'ast AsmStatement<T>, span: &'ast Span) {
         visit_asm_statement(self, asm_statement, span)
     }
 
     fn visit_availability_attribute(
         &mut self,
-        availability: &'ast AvailabilityAttribute,
+        availability: &'ast AvailabilityAttribute<T>,
         span: &'ast Span,
     ) {
         visit_availability_attribute(self, availability, span)
@@ -474,29 +474,29 @@ pub trait Visit<'ast> {
 
     fn visit_gnu_extended_asm_statement(
         &mut self,
-        gnu_extended_asm_statement: &'ast GnuExtendedAsmStatement,
+        gnu_extended_asm_statement: &'ast GnuExtendedAsmStatement<T>,
         span: &'ast Span,
     ) {
         visit_gnu_extended_asm_statement(self, gnu_extended_asm_statement, span)
     }
 
-    fn visit_gnu_asm_operand(&mut self, gnu_asm_operand: &'ast GnuAsmOperand, span: &'ast Span) {
+    fn visit_gnu_asm_operand(&mut self, gnu_asm_operand: &'ast GnuAsmOperand<T>, span: &'ast Span) {
         visit_gnu_asm_operand(self, gnu_asm_operand, span)
     }
 
-    fn visit_type_of(&mut self, type_of: &'ast TypeOf, span: &'ast Span) {
+    fn visit_type_of(&mut self, type_of: &'ast TypeOf<T>, span: &'ast Span) {
         visit_type_of(self, type_of, span)
     }
 }
 
-pub fn visit_identifier<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_identifier<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     _visitor: &mut V,
-    _identifier: &'ast Identifier,
+    _identifier: &'ast Identifier<T>,
     _span: &'ast Span,
 ) {
 }
 
-pub fn visit_constant<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_constant<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
     constant: &'ast Constant,
     span: &'ast Span,
@@ -508,7 +508,7 @@ pub fn visit_constant<'ast, V: Visit<'ast> + ?Sized>(
     }
 }
 
-pub fn visit_integer<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_integer<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
     integer: &'ast Integer,
     span: &'ast Span,
@@ -517,14 +517,14 @@ pub fn visit_integer<'ast, V: Visit<'ast> + ?Sized>(
     visitor.visit_integer_suffix(&integer.suffix, span);
 }
 
-pub fn visit_integer_base<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_integer_base<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     _visitor: &mut V,
     _integer_base: &'ast IntegerBase,
     _span: &'ast Span,
 ) {
 }
 
-pub fn visit_integer_suffix<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_integer_suffix<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
     integer_suffix: &'ast IntegerSuffix,
     span: &'ast Span,
@@ -532,14 +532,14 @@ pub fn visit_integer_suffix<'ast, V: Visit<'ast> + ?Sized>(
     visitor.visit_integer_size(&integer_suffix.size, span);
 }
 
-pub fn visit_integer_size<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_integer_size<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     _visitor: &mut V,
     _integer_size: &'ast IntegerSize,
     _span: &'ast Span,
 ) {
 }
 
-pub fn visit_float<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_float<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
     float: &'ast Float,
     span: &'ast Span,
@@ -548,14 +548,14 @@ pub fn visit_float<'ast, V: Visit<'ast> + ?Sized>(
     visitor.visit_float_suffix(&float.suffix, span);
 }
 
-pub fn visit_float_base<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_float_base<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     _visitor: &mut V,
     _float_base: &'ast FloatBase,
     _span: &'ast Span,
 ) {
 }
 
-pub fn visit_float_suffix<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_float_suffix<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
     float_suffix: &'ast FloatSuffix,
     span: &'ast Span,
@@ -563,7 +563,7 @@ pub fn visit_float_suffix<'ast, V: Visit<'ast> + ?Sized>(
     visitor.visit_float_format(&float_suffix.format, span);
 }
 
-pub fn visit_float_format<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_float_format<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
     float_format: &'ast FloatFormat,
     span: &'ast Span,
@@ -574,16 +574,16 @@ pub fn visit_float_format<'ast, V: Visit<'ast> + ?Sized>(
     }
 }
 
-pub fn visit_string_literal<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_string_literal<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     _visitor: &mut V,
     _string_literal: &'ast StringLiteral,
     _span: &'ast Span,
 ) {
 }
 
-pub fn visit_expression<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_expression<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    expression: &'ast Expression,
+    expression: &'ast Expression<T>,
     _span: &'ast Span,
 ) {
     match *expression {
@@ -615,16 +615,16 @@ pub fn visit_expression<'ast, V: Visit<'ast> + ?Sized>(
     }
 }
 
-pub fn visit_member_operator<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_member_operator<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     _visitor: &mut V,
     _member_operator: &'ast MemberOperator,
     _span: &'ast Span,
 ) {
 }
 
-pub fn visit_generic_selection<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_generic_selection<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    generic_selection: &'ast GenericSelection,
+    generic_selection: &'ast GenericSelection<T>,
     _span: &'ast Span,
 ) {
     visitor.visit_expression(
@@ -636,9 +636,9 @@ pub fn visit_generic_selection<'ast, V: Visit<'ast> + ?Sized>(
     }
 }
 
-pub fn visit_generic_association<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_generic_association<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    generic_association: &'ast GenericAssociation,
+    generic_association: &'ast GenericAssociation<T>,
     _span: &'ast Span,
 ) {
     match *generic_association {
@@ -647,9 +647,9 @@ pub fn visit_generic_association<'ast, V: Visit<'ast> + ?Sized>(
     }
 }
 
-pub fn visit_generic_association_type<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_generic_association_type<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    generic_association_type: &'ast GenericAssociationType,
+    generic_association_type: &'ast GenericAssociationType<T>,
     _span: &'ast Span,
 ) {
     visitor.visit_type_name(
@@ -662,9 +662,9 @@ pub fn visit_generic_association_type<'ast, V: Visit<'ast> + ?Sized>(
     );
 }
 
-pub fn visit_member_expression<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_member_expression<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    member_expression: &'ast MemberExpression,
+    member_expression: &'ast MemberExpression<T>,
     _span: &'ast Span,
 ) {
     visitor.visit_member_operator(
@@ -681,9 +681,9 @@ pub fn visit_member_expression<'ast, V: Visit<'ast> + ?Sized>(
     );
 }
 
-pub fn visit_call_expression<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_call_expression<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    call_expression: &'ast CallExpression,
+    call_expression: &'ast CallExpression<T>,
     _span: &'ast Span,
 ) {
     visitor.visit_expression(&call_expression.callee.node, &call_expression.callee.span);
@@ -692,9 +692,9 @@ pub fn visit_call_expression<'ast, V: Visit<'ast> + ?Sized>(
     }
 }
 
-pub fn visit_compound_literal<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_compound_literal<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    compound_literal: &'ast CompoundLiteral,
+    compound_literal: &'ast CompoundLiteral<T>,
     _span: &'ast Span,
 ) {
     visitor.visit_type_name(
@@ -706,16 +706,16 @@ pub fn visit_compound_literal<'ast, V: Visit<'ast> + ?Sized>(
     }
 }
 
-pub fn visit_unary_operator<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_unary_operator<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     _visitor: &mut V,
     _unary_operator: &'ast UnaryOperator,
     _span: &'ast Span,
 ) {
 }
 
-pub fn visit_unary_operator_expression<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_unary_operator_expression<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    unary_operator_expression: &'ast UnaryOperatorExpression,
+    unary_operator_expression: &'ast UnaryOperatorExpression<T>,
     _span: &'ast Span,
 ) {
     match unary_operator_expression.operator.node {
@@ -742,9 +742,9 @@ pub fn visit_unary_operator_expression<'ast, V: Visit<'ast> + ?Sized>(
     }
 }
 
-pub fn visit_cast_expression<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_cast_expression<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    cast_expression: &'ast CastExpression,
+    cast_expression: &'ast CastExpression<T>,
     _span: &'ast Span,
 ) {
     visitor.visit_type_name(
@@ -757,16 +757,16 @@ pub fn visit_cast_expression<'ast, V: Visit<'ast> + ?Sized>(
     );
 }
 
-pub fn visit_binary_operator<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_binary_operator<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     _visitor: &mut V,
     _binary_operator: &'ast BinaryOperator,
     _span: &'ast Span,
 ) {
 }
 
-pub fn visit_binary_operator_expression<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_binary_operator_expression<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    binary_operator_expression: &'ast BinaryOperatorExpression,
+    binary_operator_expression: &'ast BinaryOperatorExpression<T>,
     _span: &'ast Span,
 ) {
     visitor.visit_expression(
@@ -783,9 +783,9 @@ pub fn visit_binary_operator_expression<'ast, V: Visit<'ast> + ?Sized>(
     );
 }
 
-pub fn visit_conditional_expression<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_conditional_expression<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    conditional_expression: &'ast ConditionalExpression,
+    conditional_expression: &'ast ConditionalExpression<T>,
     _span: &'ast Span,
 ) {
     visitor.visit_expression(
@@ -802,9 +802,9 @@ pub fn visit_conditional_expression<'ast, V: Visit<'ast> + ?Sized>(
     );
 }
 
-pub fn visit_va_arg_expression<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_va_arg_expression<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    va_arg_expression: &'ast VaArgExpression,
+    va_arg_expression: &'ast VaArgExpression<T>,
     _span: &'ast Span,
 ) {
     visitor.visit_expression(
@@ -817,9 +817,9 @@ pub fn visit_va_arg_expression<'ast, V: Visit<'ast> + ?Sized>(
     );
 }
 
-pub fn visit_offset_of_expression<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_offset_of_expression<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    offset_of_expression: &'ast OffsetOfExpression,
+    offset_of_expression: &'ast OffsetOfExpression<T>,
     _span: &'ast Span,
 ) {
     visitor.visit_type_name(
@@ -832,9 +832,9 @@ pub fn visit_offset_of_expression<'ast, V: Visit<'ast> + ?Sized>(
     );
 }
 
-pub fn visit_offset_designator<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_offset_designator<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    offset_designator: &'ast OffsetDesignator,
+    offset_designator: &'ast OffsetDesignator<T>,
     _span: &'ast Span,
 ) {
     visitor.visit_identifier(&offset_designator.base.node, &offset_designator.base.span);
@@ -843,9 +843,9 @@ pub fn visit_offset_designator<'ast, V: Visit<'ast> + ?Sized>(
     }
 }
 
-pub fn visit_offset_member<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_offset_member<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    offset_member: &'ast OffsetMember,
+    offset_member: &'ast OffsetMember<T>,
     _span: &'ast Span,
 ) {
     match *offset_member {
@@ -855,9 +855,9 @@ pub fn visit_offset_member<'ast, V: Visit<'ast> + ?Sized>(
     }
 }
 
-pub fn visit_declaration<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_declaration<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    declaration: &'ast Declaration,
+    declaration: &'ast Declaration<T>,
     _span: &'ast Span,
 ) {
     for specifier in &declaration.specifiers {
@@ -869,9 +869,9 @@ pub fn visit_declaration<'ast, V: Visit<'ast> + ?Sized>(
     }
 }
 
-pub fn visit_declaration_specifier<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_declaration_specifier<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    declaration_specifier: &'ast DeclarationSpecifier,
+    declaration_specifier: &'ast DeclarationSpecifier<T>,
     _span: &'ast Span,
 ) {
     match *declaration_specifier {
@@ -896,9 +896,9 @@ pub fn visit_declaration_specifier<'ast, V: Visit<'ast> + ?Sized>(
     }
 }
 
-pub fn visit_init_declarator<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_init_declarator<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    init_declarator: &'ast InitDeclarator,
+    init_declarator: &'ast InitDeclarator<T>,
     _span: &'ast Span,
 ) {
     visitor.visit_declarator(
@@ -910,16 +910,16 @@ pub fn visit_init_declarator<'ast, V: Visit<'ast> + ?Sized>(
     }
 }
 
-pub fn visit_storage_class_specifier<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_storage_class_specifier<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     _visitor: &mut V,
     _storage_class_specifier: &'ast StorageClassSpecifier,
     _span: &'ast Span,
 ) {
 }
 
-pub fn visit_type_specifier<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_type_specifier<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    type_specifier: &'ast TypeSpecifier,
+    type_specifier: &'ast TypeSpecifier<T>,
     span: &'ast Span,
 ) {
     match *type_specifier {
@@ -933,7 +933,7 @@ pub fn visit_type_specifier<'ast, V: Visit<'ast> + ?Sized>(
     }
 }
 
-pub fn visit_ts18661_float_type<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_ts18661_float_type<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
     ts18661_float_type: &'ast TS18661FloatType,
     span: &'ast Span,
@@ -941,16 +941,16 @@ pub fn visit_ts18661_float_type<'ast, V: Visit<'ast> + ?Sized>(
     visitor.visit_ts18661_float_format(&ts18661_float_type.format, span);
 }
 
-pub fn visit_ts18661_float_format<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_ts18661_float_format<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     _visitor: &mut V,
     _ts18661_float_format: &'ast TS18661FloatFormat,
     _span: &'ast Span,
 ) {
 }
 
-pub fn visit_struct_type<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_struct_type<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    struct_type: &'ast StructType,
+    struct_type: &'ast StructType<T>,
     _span: &'ast Span,
 ) {
     visitor.visit_struct_kind(&struct_type.kind.node, &struct_type.kind.span);
@@ -964,16 +964,16 @@ pub fn visit_struct_type<'ast, V: Visit<'ast> + ?Sized>(
     }
 }
 
-pub fn visit_struct_kind<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_struct_kind<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     _visitor: &mut V,
     _struct_kind: &'ast StructKind,
     _span: &'ast Span,
 ) {
 }
 
-pub fn visit_struct_declaration<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_struct_declaration<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    struct_declaration: &'ast StructDeclaration,
+    struct_declaration: &'ast StructDeclaration<T>,
     _span: &'ast Span,
 ) {
     match *struct_declaration {
@@ -982,9 +982,9 @@ pub fn visit_struct_declaration<'ast, V: Visit<'ast> + ?Sized>(
     }
 }
 
-pub fn visit_struct_field<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_struct_field<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    struct_field: &'ast StructField,
+    struct_field: &'ast StructField<T>,
     _span: &'ast Span,
 ) {
     for specifier in &struct_field.specifiers {
@@ -995,9 +995,9 @@ pub fn visit_struct_field<'ast, V: Visit<'ast> + ?Sized>(
     }
 }
 
-pub fn visit_specifier_qualifier<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_specifier_qualifier<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    specifier_qualifier: &'ast SpecifierQualifier,
+    specifier_qualifier: &'ast SpecifierQualifier<T>,
     _span: &'ast Span,
 ) {
     match *specifier_qualifier {
@@ -1006,9 +1006,9 @@ pub fn visit_specifier_qualifier<'ast, V: Visit<'ast> + ?Sized>(
     }
 }
 
-pub fn visit_struct_declarator<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_struct_declarator<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    struct_declarator: &'ast StructDeclarator,
+    struct_declarator: &'ast StructDeclarator<T>,
     _span: &'ast Span,
 ) {
     if let Some(ref declarator) = struct_declarator.declarator {
@@ -1019,9 +1019,9 @@ pub fn visit_struct_declarator<'ast, V: Visit<'ast> + ?Sized>(
     }
 }
 
-pub fn visit_enum_type<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_enum_type<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    enum_type: &'ast EnumType,
+    enum_type: &'ast EnumType<T>,
     _span: &'ast Span,
 ) {
     if let Some(ref identifier) = enum_type.identifier {
@@ -1032,9 +1032,9 @@ pub fn visit_enum_type<'ast, V: Visit<'ast> + ?Sized>(
     }
 }
 
-pub fn visit_enumerator<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_enumerator<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    enumerator: &'ast Enumerator,
+    enumerator: &'ast Enumerator<T>,
     _span: &'ast Span,
 ) {
     visitor.visit_identifier(&enumerator.identifier.node, &enumerator.identifier.span);
@@ -1043,23 +1043,23 @@ pub fn visit_enumerator<'ast, V: Visit<'ast> + ?Sized>(
     }
 }
 
-pub fn visit_type_qualifier<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_type_qualifier<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     _visitor: &mut V,
     _type_qualifier: &'ast TypeQualifier,
     _span: &'ast Span,
 ) {
 }
 
-pub fn visit_function_specifier<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_function_specifier<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     _visitor: &mut V,
     _function_specifier: &'ast FunctionSpecifier,
     _span: &'ast Span,
 ) {
 }
 
-pub fn visit_alignment_specifier<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_alignment_specifier<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    alignment_specifier: &'ast AlignmentSpecifier,
+    alignment_specifier: &'ast AlignmentSpecifier<T>,
     _span: &'ast Span,
 ) {
     match *alignment_specifier {
@@ -1068,9 +1068,9 @@ pub fn visit_alignment_specifier<'ast, V: Visit<'ast> + ?Sized>(
     }
 }
 
-pub fn visit_declarator<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_declarator<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    declarator: &'ast Declarator,
+    declarator: &'ast Declarator<T>,
     _span: &'ast Span,
 ) {
     visitor.visit_declarator_kind(&declarator.kind.node, &declarator.kind.span);
@@ -1082,9 +1082,9 @@ pub fn visit_declarator<'ast, V: Visit<'ast> + ?Sized>(
     }
 }
 
-pub fn visit_declarator_kind<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_declarator_kind<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    declarator_kind: &'ast DeclaratorKind,
+    declarator_kind: &'ast DeclaratorKind<T>,
     _span: &'ast Span,
 ) {
     match *declarator_kind {
@@ -1094,9 +1094,9 @@ pub fn visit_declarator_kind<'ast, V: Visit<'ast> + ?Sized>(
     }
 }
 
-pub fn visit_derived_declarator<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_derived_declarator<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    derived_declarator: &'ast DerivedDeclarator,
+    derived_declarator: &'ast DerivedDeclarator<T>,
     _span: &'ast Span,
 ) {
     match *derived_declarator {
@@ -1115,9 +1115,9 @@ pub fn visit_derived_declarator<'ast, V: Visit<'ast> + ?Sized>(
     }
 }
 
-pub fn visit_array_declarator<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_array_declarator<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    array_declarator: &'ast ArrayDeclarator,
+    array_declarator: &'ast ArrayDeclarator<T>,
     span: &'ast Span,
 ) {
     for qualifier in &array_declarator.qualifiers {
@@ -1126,9 +1126,9 @@ pub fn visit_array_declarator<'ast, V: Visit<'ast> + ?Sized>(
     visitor.visit_array_size(&array_declarator.size, span)
 }
 
-pub fn visit_function_declarator<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_function_declarator<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    function_declarator: &'ast FunctionDeclarator,
+    function_declarator: &'ast FunctionDeclarator<T>,
     span: &'ast Span,
 ) {
     for parameter in &function_declarator.parameters {
@@ -1137,9 +1137,9 @@ pub fn visit_function_declarator<'ast, V: Visit<'ast> + ?Sized>(
     visitor.visit_ellipsis(&function_declarator.ellipsis, span);
 }
 
-pub fn visit_pointer_qualifier<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_pointer_qualifier<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    pointer_qualifier: &'ast PointerQualifier,
+    pointer_qualifier: &'ast PointerQualifier<T>,
     _span: &'ast Span,
 ) {
     match *pointer_qualifier {
@@ -1152,9 +1152,9 @@ pub fn visit_pointer_qualifier<'ast, V: Visit<'ast> + ?Sized>(
     }
 }
 
-pub fn visit_array_size<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_array_size<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    array_size: &'ast ArraySize,
+    array_size: &'ast ArraySize<T>,
     _span: &'ast Span,
 ) {
     match *array_size {
@@ -1164,9 +1164,9 @@ pub fn visit_array_size<'ast, V: Visit<'ast> + ?Sized>(
     }
 }
 
-pub fn visit_parameter_declaration<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_parameter_declaration<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    parameter_declaration: &'ast ParameterDeclaration,
+    parameter_declaration: &'ast ParameterDeclaration<T>,
     _span: &'ast Span,
 ) {
     for specifier in &parameter_declaration.specifiers {
@@ -1180,16 +1180,16 @@ pub fn visit_parameter_declaration<'ast, V: Visit<'ast> + ?Sized>(
     }
 }
 
-pub fn visit_ellipsis<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_ellipsis<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     _visitor: &mut V,
     _ellipsis: &'ast Ellipsis,
     _span: &'ast Span,
 ) {
 }
 
-pub fn visit_type_name<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_type_name<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    type_name: &'ast TypeName,
+    type_name: &'ast TypeName<T>,
     _span: &'ast Span,
 ) {
     for specifier in &type_name.specifiers {
@@ -1200,9 +1200,9 @@ pub fn visit_type_name<'ast, V: Visit<'ast> + ?Sized>(
     }
 }
 
-pub fn visit_initializer<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_initializer<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    initializer: &'ast Initializer,
+    initializer: &'ast Initializer<T>,
     _span: &'ast Span,
 ) {
     match *initializer {
@@ -1215,9 +1215,9 @@ pub fn visit_initializer<'ast, V: Visit<'ast> + ?Sized>(
     }
 }
 
-pub fn visit_initializer_list_item<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_initializer_list_item<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    initializer_list_item: &'ast InitializerListItem,
+    initializer_list_item: &'ast InitializerListItem<T>,
     _span: &'ast Span,
 ) {
     for designation in &initializer_list_item.designation {
@@ -1229,9 +1229,9 @@ pub fn visit_initializer_list_item<'ast, V: Visit<'ast> + ?Sized>(
     );
 }
 
-pub fn visit_designator<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_designator<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    designator: &'ast Designator,
+    designator: &'ast Designator<T>,
     _span: &'ast Span,
 ) {
     match *designator {
@@ -1241,18 +1241,18 @@ pub fn visit_designator<'ast, V: Visit<'ast> + ?Sized>(
     }
 }
 
-pub fn visit_range_designator<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_range_designator<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    range_designator: &'ast RangeDesignator,
+    range_designator: &'ast RangeDesignator<T>,
     _span: &'ast Span,
 ) {
     visitor.visit_expression(&range_designator.from.node, &range_designator.from.span);
     visitor.visit_expression(&range_designator.to.node, &range_designator.to.span);
 }
 
-pub fn visit_static_assert<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_static_assert<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    static_assert: &'ast StaticAssert,
+    static_assert: &'ast StaticAssert<T>,
     _span: &'ast Span,
 ) {
     visitor.visit_expression(
@@ -1262,9 +1262,9 @@ pub fn visit_static_assert<'ast, V: Visit<'ast> + ?Sized>(
     visitor.visit_string_literal(&static_assert.message.node, &static_assert.message.span);
 }
 
-pub fn visit_statement<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_statement<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    statement: &'ast Statement,
+    statement: &'ast Statement<T>,
     _span: &'ast Span,
 ) {
     match *statement {
@@ -1291,9 +1291,9 @@ pub fn visit_statement<'ast, V: Visit<'ast> + ?Sized>(
     }
 }
 
-pub fn visit_labeled_statement<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_labeled_statement<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    labeled_statement: &'ast LabeledStatement,
+    labeled_statement: &'ast LabeledStatement<T>,
     _span: &'ast Span,
 ) {
     visitor.visit_label(&labeled_statement.label.node, &labeled_statement.label.span);
@@ -1303,9 +1303,9 @@ pub fn visit_labeled_statement<'ast, V: Visit<'ast> + ?Sized>(
     );
 }
 
-pub fn visit_if_statement<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_if_statement<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    if_statement: &'ast IfStatement,
+    if_statement: &'ast IfStatement<T>,
     _span: &'ast Span,
 ) {
     visitor.visit_expression(&if_statement.condition.node, &if_statement.condition.span);
@@ -1318,9 +1318,9 @@ pub fn visit_if_statement<'ast, V: Visit<'ast> + ?Sized>(
     }
 }
 
-pub fn visit_switch_statement<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_switch_statement<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    switch_statement: &'ast SwitchStatement,
+    switch_statement: &'ast SwitchStatement<T>,
     _span: &'ast Span,
 ) {
     visitor.visit_expression(
@@ -1333,9 +1333,9 @@ pub fn visit_switch_statement<'ast, V: Visit<'ast> + ?Sized>(
     );
 }
 
-pub fn visit_while_statement<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_while_statement<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    while_statement: &'ast WhileStatement,
+    while_statement: &'ast WhileStatement<T>,
     _span: &'ast Span,
 ) {
     visitor.visit_expression(
@@ -1348,9 +1348,9 @@ pub fn visit_while_statement<'ast, V: Visit<'ast> + ?Sized>(
     );
 }
 
-pub fn visit_do_while_statement<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_do_while_statement<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    do_while_statement: &'ast DoWhileStatement,
+    do_while_statement: &'ast DoWhileStatement<T>,
     _span: &'ast Span,
 ) {
     visitor.visit_statement(
@@ -1363,9 +1363,9 @@ pub fn visit_do_while_statement<'ast, V: Visit<'ast> + ?Sized>(
     );
 }
 
-pub fn visit_for_statement<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_for_statement<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    for_statement: &'ast ForStatement,
+    for_statement: &'ast ForStatement<T>,
     _span: &'ast Span,
 ) {
     visitor.visit_for_initializer(
@@ -1381,9 +1381,9 @@ pub fn visit_for_statement<'ast, V: Visit<'ast> + ?Sized>(
     visitor.visit_statement(&for_statement.statement.node, &for_statement.statement.span);
 }
 
-pub fn visit_label<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_label<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    label: &'ast Label,
+    label: &'ast Label<T>,
     _span: &'ast Span,
 ) {
     match *label {
@@ -1393,9 +1393,9 @@ pub fn visit_label<'ast, V: Visit<'ast> + ?Sized>(
     }
 }
 
-pub fn visit_for_initializer<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_for_initializer<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    for_initializer: &'ast ForInitializer,
+    for_initializer: &'ast ForInitializer<T>,
     _span: &'ast Span,
 ) {
     match *for_initializer {
@@ -1406,9 +1406,9 @@ pub fn visit_for_initializer<'ast, V: Visit<'ast> + ?Sized>(
     }
 }
 
-pub fn visit_block_item<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_block_item<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    block_item: &'ast BlockItem,
+    block_item: &'ast BlockItem<T>,
     _span: &'ast Span,
 ) {
     match *block_item {
@@ -1418,18 +1418,18 @@ pub fn visit_block_item<'ast, V: Visit<'ast> + ?Sized>(
     }
 }
 
-pub fn visit_translation_unit<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_translation_unit<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    translation_unit: &'ast TranslationUnit,
+    translation_unit: &'ast TranslationUnit<T>,
 ) {
     for element in &translation_unit.0 {
         visitor.visit_external_declaration(&element.node, &element.span);
     }
 }
 
-pub fn visit_external_declaration<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_external_declaration<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    external_declaration: &'ast ExternalDeclaration,
+    external_declaration: &'ast ExternalDeclaration<T>,
     _span: &'ast Span,
 ) {
     match *external_declaration {
@@ -1441,9 +1441,9 @@ pub fn visit_external_declaration<'ast, V: Visit<'ast> + ?Sized>(
     }
 }
 
-pub fn visit_function_definition<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_function_definition<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    function_definition: &'ast FunctionDefinition,
+    function_definition: &'ast FunctionDefinition<T>,
     _span: &'ast Span,
 ) {
     for specifier in &function_definition.specifiers {
@@ -1462,9 +1462,9 @@ pub fn visit_function_definition<'ast, V: Visit<'ast> + ?Sized>(
     );
 }
 
-pub fn visit_extension<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_extension<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    extension: &'ast Extension,
+    extension: &'ast Extension<T>,
     span: &'ast Span,
 ) {
     match *extension {
@@ -1476,9 +1476,9 @@ pub fn visit_extension<'ast, V: Visit<'ast> + ?Sized>(
     }
 }
 
-pub fn visit_attribute<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_attribute<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    attribute: &'ast Attribute,
+    attribute: &'ast Attribute<T>,
     _span: &'ast Span,
 ) {
     for argument in &attribute.arguments {
@@ -1486,9 +1486,9 @@ pub fn visit_attribute<'ast, V: Visit<'ast> + ?Sized>(
     }
 }
 
-pub fn visit_asm_statement<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_asm_statement<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    asm_statement: &'ast AsmStatement,
+    asm_statement: &'ast AsmStatement<T>,
     span: &'ast Span,
 ) {
     match *asm_statement {
@@ -1497,9 +1497,9 @@ pub fn visit_asm_statement<'ast, V: Visit<'ast> + ?Sized>(
     }
 }
 
-pub fn visit_availability_attribute<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_availability_attribute<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    availability: &'ast AvailabilityAttribute,
+    availability: &'ast AvailabilityAttribute<T>,
     _span: &'ast Span,
 ) {
     for clause in &availability.clauses {
@@ -1507,9 +1507,9 @@ pub fn visit_availability_attribute<'ast, V: Visit<'ast> + ?Sized>(
     }
 }
 
-pub fn visit_gnu_extended_asm_statement<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_gnu_extended_asm_statement<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    gnu_extended_asm_statement: &'ast GnuExtendedAsmStatement,
+    gnu_extended_asm_statement: &'ast GnuExtendedAsmStatement<T>,
     _span: &'ast Span,
 ) {
     if let Some(ref qualifier) = gnu_extended_asm_statement.qualifier {
@@ -1530,9 +1530,9 @@ pub fn visit_gnu_extended_asm_statement<'ast, V: Visit<'ast> + ?Sized>(
     }
 }
 
-pub fn visit_gnu_asm_operand<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_gnu_asm_operand<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    gnu_asm_operand: &'ast GnuAsmOperand,
+    gnu_asm_operand: &'ast GnuAsmOperand<T>,
     _span: &'ast Span,
 ) {
     if let Some(ref name) = gnu_asm_operand.symbolic_name {
@@ -1548,9 +1548,9 @@ pub fn visit_gnu_asm_operand<'ast, V: Visit<'ast> + ?Sized>(
     );
 }
 
-pub fn visit_type_of<'ast, V: Visit<'ast> + ?Sized>(
+pub fn visit_type_of<'ast, V: Visit<'ast, T> + ?Sized, T: Name>(
     visitor: &mut V,
-    type_of: &'ast TypeOf,
+    type_of: &'ast TypeOf<T>,
     _span: &'ast Span,
 ) {
     match *type_of {

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -106,7 +106,11 @@ pub trait Visit<'ast, T: Name = String> {
         visit_member_expression(self, member_expression, span)
     }
 
-    fn visit_call_expression(&mut self, call_expression: &'ast CallExpression<T>, span: &'ast Span) {
+    fn visit_call_expression(
+        &mut self,
+        call_expression: &'ast CallExpression<T>,
+        span: &'ast Span,
+    ) {
         visit_call_expression(self, call_expression, span)
     }
 
@@ -130,7 +134,11 @@ pub trait Visit<'ast, T: Name = String> {
         visit_unary_operator_expression(self, unary_operator_expression, span)
     }
 
-    fn visit_cast_expression(&mut self, cast_expression: &'ast CastExpression<T>, span: &'ast Span) {
+    fn visit_cast_expression(
+        &mut self,
+        cast_expression: &'ast CastExpression<T>,
+        span: &'ast Span,
+    ) {
         visit_cast_expression(self, cast_expression, span)
     }
 
@@ -194,7 +202,11 @@ pub trait Visit<'ast, T: Name = String> {
         visit_declaration_specifier(self, declaration_specifier, span)
     }
 
-    fn visit_init_declarator(&mut self, init_declarator: &'ast InitDeclarator<T>, span: &'ast Span) {
+    fn visit_init_declarator(
+        &mut self,
+        init_declarator: &'ast InitDeclarator<T>,
+        span: &'ast Span,
+    ) {
         visit_init_declarator(self, init_declarator, span)
     }
 
@@ -294,7 +306,11 @@ pub trait Visit<'ast, T: Name = String> {
         visit_declarator(self, declarator, span)
     }
 
-    fn visit_declarator_kind(&mut self, declarator_kind: &'ast DeclaratorKind<T>, span: &'ast Span) {
+    fn visit_declarator_kind(
+        &mut self,
+        declarator_kind: &'ast DeclaratorKind<T>,
+        span: &'ast Span,
+    ) {
         visit_declarator_kind(self, declarator_kind, span)
     }
 
@@ -402,7 +418,11 @@ pub trait Visit<'ast, T: Name = String> {
         visit_switch_statement(self, switch_statement, span)
     }
 
-    fn visit_while_statement(&mut self, while_statement: &'ast WhileStatement<T>, span: &'ast Span) {
+    fn visit_while_statement(
+        &mut self,
+        while_statement: &'ast WhileStatement<T>,
+        span: &'ast Span,
+    ) {
         visit_while_statement(self, while_statement, span)
     }
 
@@ -422,7 +442,11 @@ pub trait Visit<'ast, T: Name = String> {
         visit_label(self, label, span)
     }
 
-    fn visit_for_initializer(&mut self, for_initializer: &'ast ForInitializer<T>, span: &'ast Span) {
+    fn visit_for_initializer(
+        &mut self,
+        for_initializer: &'ast ForInitializer<T>,
+        span: &'ast Span,
+    ) {
         visit_for_initializer(self, for_initializer, span)
     }
 


### PR DESCRIPTION
Hello,

as you probably are aware of, many compilers use string interning on identifier and type name tokens in order to avoid heap allocation and to allow for faster equality comparison between identifier names. Generally Strings are interned during tolkinization. Unfortunately lang-c currently only allows for identifiers and type names to be stored in `std::String`. As I don't want to change the default behaviour, introduce dependencies on external crates or bless a particular string interning library, I came up with a solution where the ast and parser are converted into generic functions. The only issue with this solution is, that I somehow have to work around `rust-peg`'s limitations. This is done by some string substitution on the `parser.rs.raw`. While I tried my best to modify the code in a fashion, that avoids breaking the public API, I cannot guarantee, whether I succeeded.

I am fully aware, that this use of `rust-peg` could be considered a hack and you might be reluctant to merge this. Please fell free to close this pull request in this case. Given that you considered merging https://github.com/vickenty/lang-c/pull/18 and I wasn't certain, how this would effect my string substitution, I also made a version, where this change is applied, https://github.com/nacaclanga/lang-c/tree/generic_ident_conditional, which you could consider merging instead.

Merry Christmas