### PR TITLE
Implemented the `Deref` & `DerefMut` trait for ``Node<T>`

### DIFF
--- a/src/print.rs
+++ b/src/print.rs
@@ -69,7 +69,7 @@ impl<'ast, 'a> Visit<'ast> for Printer<'a> {
                 self.field("Character");
                 self.field(c);
             }
-            _ => {},
+            _ => {}
         }
 
         visit_constant(&mut self.block(), n, span);

--- a/src/span.rs
+++ b/src/span.rs
@@ -64,3 +64,17 @@ impl<T> Node<T> {
         }
     }
 }
+
+impl<T> std::ops::Deref for Node<T> {
+    type Target = T;
+    
+    fn deref(&self) -> &Self::Target {
+        &self.node
+    }
+}
+
+impl<T> std::ops::DerefMut for Node<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.node
+    }
+}

--- a/src/span.rs
+++ b/src/span.rs
@@ -67,7 +67,7 @@ impl<T> Node<T> {
 
 impl<T> std::ops::Deref for Node<T> {
     type Target = T;
-    
+
     fn deref(&self) -> &Self::Target {
         &self.node
     }


### PR DESCRIPTION
Hi,
It is currently very hard and ugly to use your library cuz `Node<T>` does not implement the `Deref` traits.
Before you needed to write (only a general example):
```rust
func.node.ty.args.node.iter()
```
Now you can write:
```rust
func.ty.args.iter()
```

While still being able to acess the inner span.

Bye